### PR TITLE
Core docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "kernelci.org/themes/docsy"]
 	path = kernelci.org/themes/docsy
 	url = https://github.com/google/docsy.git
+[submodule "kernelci.org/external/kernelci-core"]
+	path = kernelci.org/external/kernelci-core
+	url = https://github.com/kernelci/kernelci-core.git

--- a/kernelci.org/content/en/docs/core
+++ b/kernelci.org/content/en/docs/core
@@ -1,0 +1,1 @@
+../../../external/kernelci-core/doc


### PR DESCRIPTION
Add a git submodule with kernelci-core and include the documentation files from there into `docs/core`.

See also: https://github.com/kernelci/kernelci-core/pull/608

Now deployed on https://staging.kernelci.org:8080/docs/core/