### PR TITLE
kernelci.org: update GitHub branch and directory in config.toml

### DIFF
--- a/kernelci.org/config.toml
+++ b/kernelci.org/config.toml
@@ -21,6 +21,8 @@ pygmentsStyle = "tango"
 [params]
 copyright = "KernelCI"
 github_repo = "https://github.com/kernelci/kernelci-project"
+github_branch = "main"
+github_subdir = "kernelci.org"
 
 # -- docsy parameters --
 


### PR DESCRIPTION
Add the branch name and sub-directory settings to config.toml.  This
fixes the handy links used in the Documentation section to directly
edit or add pages on the GitHub web UI.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>