### PR TITLE
kernelci.org: replace KCIDB url with kcidb.kernelci.org

### DIFF
--- a/kernelci.org/content/en/_index.html
+++ b/kernelci.org/content/en/_index.html
@@ -54,7 +54,7 @@ To find about all the KernelCI latest news.
 {{< /blocks/section >}}
 
 {{< blocks/section >}}
-{{% blocks/feature icon="fa-chart-bar" title="KCIDB Dashboard (&#946;)" url="https://staging.kernelci.org:3000/" %}}
+{{% blocks/feature icon="fa-chart-bar" title="KCIDB Dashboard (&#946;)" url="https://kcidb.kernelci.org/" %}}
 The prototype KCIDB dashboard shows all the results currently being collected.
 {{% /blocks/feature %}}
 


### PR DESCRIPTION
The KCIDB Grafana dashboard is now hosted on kcidb.kernelci.org rather
than the temporary port 3000.  Update the link URL accordingly.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>