### PR TITLE
kernelci.org: add About section

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+kernelci.org/content/en/about/background.jpeg filter=lfs diff=lfs merge=lfs -text

--- a/kernelci.org/content/en/about/_index.html
+++ b/kernelci.org/content/en/about/_index.html
@@ -1,0 +1,88 @@
+---
+title: About KernelCI
+linkTitle: About
+menu: main
+---
+
+
+{{< blocks/cover title="About KernelCI" image_anchor="bottom" height="min" >}}
+
+<p class="text-center font-weight-bold">
+  KernelCI is a project driven by the wider kernel community as well as its
+  Linux Foundation members.
+<p>
+<p class="text-center font-weight-bold">
+  Please feel free to get in touch and take part in
+  shaping the future of test-driven kernel development.
+</p>
+
+{{< /blocks/cover >}}
+
+
+
+{{< blocks/section color="white">}}
+{{% blocks/feature icon="fa-paper-plane" title="Mailing list" url="https://groups.io/g/kernelci/topics" %}}
+Send an email to <a href="mailto:kernelci@groups.io">kernelci@groups.io</a>
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fa-comment-dots" title="IRC" %}}
+<span style="font-family: mono">#kernelci</span> on Freenode
+{{% /blocks/feature %}}
+
+{{% blocks/feature icon="fab fa-linux" title="Linux Foundation" url="https://foundation.kernelci.org/" %}}
+KernelCI is a Linux Foundation project.
+{{% /blocks/feature %}}
+{{< /blocks/section >}}
+
+{{< blocks/section color="secondary" >}}
+
+<div class="col">
+  <h1 class="text-center">Retrospective</h1>
+
+  <h2>Founders</h2>
+  <p>
+    The KernelCI project was started in 2014 by:
+  </p>
+  <ul>
+    <li>Tyler Baker</li>
+    <li>Alan Bennett</li>
+    <li>Milo Casagrande</li>
+    <li>Kevin Hilman</li>
+  </ul>
+
+  <h2>Board donations</h2>
+  <p>
+    We are thankful to the individuals and organisations who have donated
+    hardware in the past to various test labs with the purpose of increasing
+    KernelCI's coverage.  Here's a non-exhaustive list:
+  </p>
+  <ul class="row">
+    <li class="col-sm-3 col-md-2">Altera</li>
+    <li class="col-sm-3 col-md-2">Atmel</li>
+    <li class="col-sm-3 col-md-2">Annapurna Labs</li>
+    <li class="col-sm-3 col-md-2">ARM</li>
+    <li class="col-sm-3 col-md-2">Broadcom</li>
+    <li class="col-sm-3 col-md-2">Compulab</li>
+    <li class="col-sm-3 col-md-2">EnergyMicro</li>
+    <li class="col-sm-3 col-md-2">Freescale</li>
+    <li class="col-sm-3 col-md-2">GlobalScale Technologies</li>
+    <li class="col-sm-3 col-md-2">Google</li>
+    <li class="col-sm-3 col-md-2">Gumstix</li>
+    <li class="col-sm-3 col-md-2">Hewlett Packard Enterprise</li>
+    <li class="col-sm-3 col-md-2">MediaTek</li>
+    <li class="col-sm-3 col-md-2">Next Thing</li>
+    <li class="col-sm-3 col-md-2">Nvidia</li>
+    <li class="col-sm-3 col-md-2">OpenBlocks</li>
+    <li class="col-sm-3 col-md-2">Pine64</li>
+    <li class="col-sm-3 col-md-2">Renesas</li>
+    <li class="col-sm-3 col-md-2">Rockchip</li>
+    <li class="col-sm-3 col-md-2">Sony Mobile</li>
+    <li class="col-sm-3 col-md-2">Qualcomm</li>
+    <li class="col-sm-3 col-md-2">ST</li>
+    <li class="col-sm-3 col-md-2">TI</li>
+    <li class="col-sm-3 col-md-2">Toradex</li>
+    <li class="col-sm-3 col-md-2">Xilinx</li>
+  </ul>
+</div>
+
+{{< /blocks/section >}}

--- a/kernelci.org/content/en/about/background.jpeg
+++ b/kernelci.org/content/en/about/background.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c58f6285d9d67b892550ee6a12fe792f91777d8fba69b40fa2670bb024e12353
+size 1363809


### PR DESCRIPTION
Add an "About" section with static content moved from the dashboard
pages "sponsors" and "contact".

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>