### PR TITLE
kernelci.org: change dashboard URL to linux.kernelci.org

### DIFF
--- a/kernelci.org/config.toml
+++ b/kernelci.org/config.toml
@@ -76,7 +76,7 @@ footer_about_disable = false
   [[menu.main]]
     identifier = "dashboard"
     name = "Dashboard"
-    url = "https://kernelci.org/job/"
+    url = "https://linux.kernelci.org/job"
 
   [[menu.main]]
     identifier = "lf"

--- a/kernelci.org/content/en/_index.html
+++ b/kernelci.org/content/en/_index.html
@@ -5,7 +5,7 @@ linkTitle = "KernelCI"
 
 {{< blocks/cover title="Welcome to KernelCI" image_anchor="top" height="full" color="blue" >}}
 <div class="mx-auto">
-  <a class="btn btn-lg btn-primary mr-3 mb-4" href="https://kernelci.org/job/">
+  <a class="btn btn-lg btn-primary mr-3 mb-4" href="https://linux.kernelci.org/job/">
     Dashboard <i class="fas fa-arrow-alt-circle-right ml-2"></i>
   </a>
   <p class="lead mt-5 mb-5 font-weight-bold">Ensuring the quality, stability and long-term maintenance of the Linux kernel</p>
@@ -19,7 +19,7 @@ KernelCI is a community-led test system focused on the upstream Linux kernel.  I
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" >}}
-{{% blocks/feature icon="fa-chart-line" title="Dashboard" url="https://kernelci.org/job/" %}}
+{{% blocks/feature icon="fa-chart-line" title="Dashboard" url="https://linux.kernelci.org/job/" %}}
 See the latest KernelCI test results.
 {{% /blocks/feature %}}
 

--- a/kernelci.org/content/en/docs/team/tsc.md
+++ b/kernelci.org/content/en/docs/team/tsc.md
@@ -76,7 +76,7 @@ generates email reports, tracks regressions and triggers automated bisections.
 ### Frontend
 
 The KernelCI frontend provides a dynamic [web
-dashboard](https://kernelci.org/job/) showing the data available from the
+dashboard](https://linux.kernelci.org/job/) showing the data available from the
 backend.
 
 * Main repository: [`kernelci-frontend`](https://github.com/kernelci/kernelci-frontend)


### PR DESCRIPTION
Update the web dashboard URLs to point to linux.kernelci.org as the
static website is being deployed on kernelci.org.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>