### PR TITLE
git cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-kernelci.org/content/en/about/background.jpeg filter=lfs diff=lfs merge=lfs -text

--- a/kernelci.org/.gitattributes
+++ b/kernelci.org/.gitattributes
@@ -11,3 +11,4 @@ static/favicons/android-48x48.png filter=lfs diff=lfs merge=lfs -text
 static/favicons/favicon-1024.png filter=lfs diff=lfs merge=lfs -text
 assets/icons/logo.png filter=lfs diff=lfs merge=lfs -text
 content/en/background.jpeg filter=lfs diff=lfs merge=lfs -text
+content/en/about/background.jpeg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Move git-lfs meta-data for the `baground.png` for the About section to `kernelci.org/.gitattributes` to keep it self-contained.