### PR TITLE
kernelci.org: Add alicef as TSC member

### DIFF
--- a/kernelci.org/content/en/docs/team/tsc.md
+++ b/kernelci.org/content/en/docs/team/tsc.md
@@ -24,6 +24,7 @@ respective email address and IRC nicknames:
 * [Michał Gałka](mailto:<michal.galka@collabora.com>) - `mgalka`
 * [Alexandra Pereira](mailto:<alexandra.pereira@collabora.com>) - `apereira`
 * [Lakshmipathi Ganapathi](mailto:<lakshmipathi.ganapathi@collabora.com>)
+* [Alice Ferrazzi](mailto:<alice.ferrazzi@miraclelinux.com>) - `alicef`
 
 For general discussions, the regular
 [`kernelci@groups.io`](mailto:<kernelci@groups.io>) mailing list can be used.

--- a/kernelci.org/content/en/docs/team/tsc.md
+++ b/kernelci.org/content/en/docs/team/tsc.md
@@ -60,7 +60,7 @@ The [core tools](/docs/core) provide the command line utilities and the
 `kernelci` Python package used to implement a KerneLCI pipeline.
 
 * Repository: [`kernelci-core`](https://github.com/kernelci/kernelci-core)
-* Maintainer: `gtucker`
+* Maintainers: `gtucker`, `alicef`
 * Deputy: `mgalka`
 
 ### Backend


### PR DESCRIPTION
I will be involved with 
- kernelci-core
- testing
- setting up and maintaining the cip.kernelci.org instance
- lava-docker