### PR TITLE
 Docs: add section for CIP instance

### DIFF
--- a/kernelci.org/content/en/docs/team/tsc.md
+++ b/kernelci.org/content/en/docs/team/tsc.md
@@ -213,6 +213,16 @@ containers.
 * Components: [`kernelci-deploy`](https://github.com/kernelci/kernelci-deploy)
 
 
+### CIP instance
+
+Dashboard: TBD
+
+The CIP instance is dedicated to building CIP specific kernels with CIP 
+configurations. Currently the CIP KernelCI code is in production.
+
+* Maintainers: `alicef`
+* Components: [`kernelci-deploy`](https://github.com/kernelci/kernelci-deploy)
+
 ## Channel Maintainers
 
 ### IRC


### PR DESCRIPTION
Add a section for the CIP instance to the TSC documentation page with designated maintainers.

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>