### PR TITLE
IRC channel has moved to libera.chat

### DIFF
--- a/kernelci.org/content/en/about/_index.html
+++ b/kernelci.org/content/en/about/_index.html
@@ -26,7 +26,7 @@ Send an email to <a href="mailto:kernelci@groups.io">kernelci@groups.io</a>
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fa-comment-dots" title="IRC" %}}
-<span style="font-family: mono">#kernelci</span> on Freenode
+<span style="font-family: mono">#kernelci</span> on libera.chat
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fab fa-linux" title="Linux Foundation" url="https://foundation.kernelci.org/" %}}


### PR DESCRIPTION
We've moved away from Freenode. Update static website accordingly.