### PR TITLE
kernelci.org: update docs for the staging instance

### DIFF
--- a/kernelci.org/content/en/docs/instances/_index.md
+++ b/kernelci.org/content/en/docs/instances/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Instances"
 date: 2021-07-21T21:00:00Z
-draft: true
+draft: false
 description: "KernelCI public instances"
 ---
 


### PR DESCRIPTION
Update the page about the staging instance to align it with the
current state of things.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>