### PR TITLE
kernelci.org: drop Pine H64 from kselftest summary table

### DIFF
--- a/kernelci.org/content/en/docs/tests/kselftest.md
+++ b/kernelci.org/content/en/docs/tests/kselftest.md
@@ -43,4 +43,3 @@ kernel revisions.
 | mt8173-elm-hana                    | arm64   | ✔           | ✔     | ✔   | ✔     | ✔       |
 | mt8183-kukui-jacuzzi-juniper-sku16 | arm64   | ✔           | ✔     | ✔   | ✔     | ✔       |
 | rk3288-veyron-jaq                  | arm     |             |       | ✔   |       |         |
-| sun50i-h6-pine-h64                 | arm64   | ✔           |       |     |       | ✔       |


### PR DESCRIPTION
The Pine H64 board is failing to run kselftest in Collabora's LAVA
lab, so drop it from the summary table in the docs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>