### PR TITLE
kernelci.org: Add advisory board members

### DIFF
--- a/kernelci.org/content/en/docs/team/board.md
+++ b/kernelci.org/content/en/docs/team/board.md
@@ -6,11 +6,29 @@ description: "Representatives from each member organization"
 ---
 
 The Advisory Board (AB) is composed of one representative from each premium
-member organization.  The board elects one Chair and one Treasurer each year.
-A budget is agreed each year and voted by the board.
+member organization, one representative for every five general member
+organizations (maximum of three) and the TSC Chair.
 
-There is also a Program Manager role to help coordinating things
-with the wider team.
+The board elects one Chair and one Treasurer each year. A budget is agreed each
+year and voted by the board.
+
+There is also a Project Manager role to help coordinating things with the wider
+team.
+
+As of today, the Advisory Board is composed of the members listed below with
+their respective roles, email address and IRC nicknames:
+
+* [Chris Paterson](mailto:<chris.paterson2@renesas.com>) (CIP, Treasurer) - `patersonc`
+* [Don Zickus](mailto:<dzickus@redhat.com>) (Redhat)
+* [Greg Kroah-Hartman](mailto:<gregkh@linuxfoundation.org>) (Linux Foundation) - `gregkh`
+* [Guenter Roeck](mailto:<groeck@google.com>) (Google)
+* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) (Collabora, Chair and Acting TSC Chair) - `gtucker`
+* [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) (Collabora, Project Manager) - `padovan`
+* [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) (Collabora, Marketing) - `glunardi`
+* [Kevin Hilman](mailto:<khilman@baylibre.com>) (BayLibre, General Members Representative) - `khilman`
+* [KY Srinivasan](mailto:<kys@microsoft.com>) (Microsoft)
+* [Veronika Kabatov](mailto:<vkabatov@redhat.com>) (Redhat) - `vkabatova`
+
 
 Learn more about the current members or how to join on the [KernelCI Linux
 Foundation](https://foundation.kernelci.org/) website.


### PR DESCRIPTION
Some information still needs adding for the members, and the list may not be complete.