### PR TITLE
kernelci.org: add paragraph with kernelci-members email button

### DIFF
--- a/kernelci.org/content/en/_index.html
+++ b/kernelci.org/content/en/_index.html
@@ -75,6 +75,24 @@ How to get started with submitting your own Linux kernel test results to KCIDB.
   <h1 class="text-center pb-5">Members</h1>
 </div>
 
+<div class="text-center col-12 pb-5">
+  <p>
+    The success of the KernelCI project will be driven by contributions from
+    our developer community and organizations joining as members.
+  </p>
+  <p>
+    Learn how your organization can contribute to the project now.
+  </p>
+  <p>
+    Organizations interested in joining KernelCI, can send us an email.
+  </p>
+  <p>
+    <a class="btn btn-outline-primary btn-lg" href="mailto:kernelci-members@groups.io?subject=KernelCI membership information request">
+      EMAIL US ABOUT JOINING THE PROJECT
+    </a>
+  </p>
+</div>
+
 <div class="col-sm mb-5 mb-sm-0 w-50">
   <a href="https://baylibre.com/" target="_blank"><img src="image/baylibre-horizontal-color.svg" /></a>
 </div>


### PR DESCRIPTION
Copy the paragraph and kernelci-members email button from
https://foundation.kernelci.org/ as an interim solution until the
foundation.kernelci.org content gets merged with the kernelci.org
static site.

Suggested-by: Guy Lunardi <guy.lunardi@collabora.com>
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>