### PR TITLE
kernelci.org: add Hugo weight attributes in documentation

### DIFF
--- a/kernelci.org/content/en/docs/instances/_index.md
+++ b/kernelci.org/content/en/docs/instances/_index.md
@@ -3,6 +3,7 @@ title: "Instances"
 date: 2021-07-21T21:00:00Z
 draft: false
 description: "KernelCI public instances"
+weight: 1
 ---
 
 There are a number of KernelCI instances for various purposes.  The main

--- a/kernelci.org/content/en/docs/team/_index.md
+++ b/kernelci.org/content/en/docs/team/_index.md
@@ -3,6 +3,7 @@ title: "Team"
 date: 2021-02-10T11:41:03Z
 draft: true
 description: "Meet the KernelCI team"
+weight: 2
 ---
 
 The KernelCI Linux Foundation project team is composed of an Advisory Board and

--- a/kernelci.org/content/en/docs/tests/_index.md
+++ b/kernelci.org/content/en/docs/tests/_index.md
@@ -3,6 +3,7 @@ title: "Tests"
 date: 2021-08-04
 draft: false
 description: KernelCI Tests
+weight: 3
 ---
 
 ## Native tests

--- a/kernelci.org/content/en/docs/tests/kselftest.md
+++ b/kernelci.org/content/en/docs/tests/kselftest.md
@@ -1,8 +1,9 @@
 ---
 title: "kselftest"
-date: 2021-07-21T18:00:00Z
-draft: true
+date: 2021-08-05
+draft: false
 description: "Native tests: kselftest"
+weight: 2
 ---
 
 ## About

--- a/kernelci.org/content/en/docs/tests/ltp.md
+++ b/kernelci.org/content/en/docs/tests/ltp.md
@@ -1,8 +1,9 @@
 ---
 title: "LTP"
-date: 2021-07-21T13:30:00Z
-draft: true
+date: 2021-08-05
+draft: false
 description: "Native tests: LTP"
+weight: 3
 ---
 
 ## About


### PR DESCRIPTION
Add Hugo weight attributes to a number of sections and pages in the
documentation to sort them in the index.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>