### PR TITLE
Add more information about the project to the about pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To set up a local development server with Docker:
 $ git clone https://github.com/kernelci/kernelci-project.git
 $ cd kernelci.org
 $ sudo apt install -y git-lfs
+$ git-lfs fetch
 $ git-lfs checkout
 $ git submodule update --init --recursive
 $ docker run -v $PWD:/src -p 1313:1313 klakegg/hugo:0.80.0-ext-debian server -D

--- a/kernelci.org/content/en/about/_index.html
+++ b/kernelci.org/content/en/about/_index.html
@@ -6,21 +6,68 @@ menu: main
 
 
 {{< blocks/cover title="About KernelCI" image_anchor="bottom" height="min" >}}
-
-<p class="text-center font-weight-bold">
-  KernelCI is a project driven by the wider kernel community as well as its
-  Linux Foundation members.
-<p>
-<p class="text-center font-weight-bold">
-  Please feel free to get in touch and take part in
-  shaping the future of test-driven kernel development.
-</p>
-
 {{< /blocks/cover >}}
 
+{{< blocks/lead color="primary" >}}
 
+<div class="row">
+  <h3>
+    KernelCI is a community-based open source distributed test automation system
+    focused on upstream kernel development
+  </h3>
+</div>
+
+{{< /blocks/lead >}}
+
+{{< blocks/section color="dark" >}}
+
+<div class="row">
+  <p>
+    The primary goal of KernelCI is to use an open testing philosophy to ensure
+    the quality, stability and long-term maintenance of the Linux kernel.
+  </p>
+  <p>
+    The Project is currently working on improved LTS kernel testing and
+    validation; consolidation of existing testing initiatives; quality-of-life
+    improvements to the current service; expanded compute resources; and
+    increased pool of hardware to be tested.
+  </p>
+  <p>
+    The Linux kernel is developed by a large, collaborative open source
+    community working together to continuously improve the software. Conversely,
+    Linux kernel testing has often fragmented since it is largely done in
+    private silos with little collaboration on the testing software or
+    methodologies. Because Linux runs on more hardware than any other operating
+    system, it’s important to test it on the most hardware possible. KernelCI
+    standardizes hardware testing for the Linux kernel across the broadest
+    possible hardware.
+  </p>
+  <p>
+    KernelCI was originally started in 2014 as a side project by a few engineers
+    who were doing the testing at home and in their spare time. A variety of
+    hardware labs contributed to the work over time, but until now there was no
+    sustainable structure in place for open governance and contribution, or
+    expanded access for the developers to hardware. Today, under the Linux
+    Foundation, companies and individuals can contribute to expanding testing
+    and integration across more hardware than ever before.
+  </p>
+</div>
+
+{{< /blocks/section >}}
 
 {{< blocks/section color="white">}}
+
+<div class="col text-center">
+  <h3>
+    Please get in touch and take part in shaping the future of test-driven
+    kernel development
+  </h3>
+</div>
+
+{{< /blocks/section >}}
+
+{{< blocks/section color="white">}}
+
 {{% blocks/feature icon="fa-paper-plane" title="Mailing list" url="https://groups.io/g/kernelci/topics" %}}
 Send an email to <a href="mailto:kernelci@groups.io">kernelci@groups.io</a>
 {{% /blocks/feature %}}

--- a/kernelci.org/content/en/about/_index.html
+++ b/kernelci.org/content/en/about/_index.html
@@ -51,6 +51,11 @@ menu: main
     Foundation, companies and individuals can contribute to expanding testing
     and integration across more hardware than ever before.
   </p>
+  <p>
+    Navigate the documentation website to view the project's
+    <a href="/docs/org/">mission statement</a> and
+    <a href="/docs/org/members">member organizations</a>.
+  </p>
 </div>
 
 {{< /blocks/section >}}


### PR DESCRIPTION
Add more content from the current https://foundation.kernelci.org/ website as part of https://github.com/kernelci/kernelci-project/issues/43.