### PR TITLE
Add template for kernel bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/kernel-bug.md
+++ b/.github/ISSUE_TEMPLATE/kernel-bug.md
@@ -1,0 +1,18 @@
+---
+name: Kernel Bug
+about: Any kernel issue discovered by KernelCI
+title: "`short git sha1` short description"
+labels: kernel
+assignees: ''
+
+---
+
+* Commit: https://github.com/torvalds/linux/commit/<git sha1> `<git subject>`
+* Regressions:
+  * https://linux.kernelci.org/test/case/id/<id>/
+  * https://linux.kernelci.org/test/case/id/<id>/
+* Email: https://lore.kernel.org/lkml/<thread>
+* Bisection report:
+```
+<Summary from email>
+```


### PR DESCRIPTION
Add a GitHub issue template for kernel bugs, to keep track on the workboard: https://github.com/orgs/kernelci/projects/6