### PR TITLE
kernelci.org: add Slack maintainers on TSC page

### DIFF
--- a/kernelci.org/content/en/docs/org/tsc.md
+++ b/kernelci.org/content/en/docs/org/tsc.md
@@ -276,7 +276,7 @@ The [KernelCI Slack channel](https://kernelci.slack.com) may be used as an
 alternative to IRC.  However, more people are using IRC so Slack is only there
 to facilitate communication when IRC is not practical.
 
-* Maintainers: `khilman`
+* Maintainers: `khilman`, `spbnick`, `gtucker`
 
 ### kernelci.org update emails
 


### PR DESCRIPTION
Add gtucker and spbnick as maintainers for Slack on the TSC org page.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>