### PR TITLE
kernelci.org: add image/kernelci-horizontal-color.png

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,4 @@ kernelci.org/content/en/blog/posts/2020/08/21/revision1.png filter=lfs diff=lfs 
 kernelci.org/content/en/blog/posts/2020/08/21/kcidb_object_relations.svg filter=lfs diff=lfs merge=lfs -text
 kernelci.org/content/en/blog/posts/2020/08/21/kcidb_object_submitting.gif filter=lfs diff=lfs merge=lfs -text
 kernelci.org/content/en/blog/posts/2021/03/16/looking-back-looking-forward.png filter=lfs diff=lfs merge=lfs -text
+kernelci.org/static/image/kernelci-horizontal-color.png filter=lfs diff=lfs merge=lfs -text

--- a/kernelci.org/static/image/kernelci-horizontal-color.png
+++ b/kernelci.org/static/image/kernelci-horizontal-color.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e0468948f4a7605da475be4061888ab396a75d9dc963c87bdcf6acabff86729
+size 42534


### PR DESCRIPTION
Add the KernelCI logo as a static file so it can be used in various
places including README files for the trade mark application.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>