### PR TITLE
Add working groups

### DIFF
--- a/kernelci.org/content/en/docs/org/_index.md
+++ b/kernelci.org/content/en/docs/org/_index.md
@@ -10,7 +10,8 @@ aliases:
 
 The KernelCI Linux Foundation project is composed of an [Advisory Board](board)
 with representatives from all the [member organizations](members) as well as a
-[Technical Steering Committee](tsc).
+[Technical Steering Committee](tsc).  A number of [working
+groups](working-groups) are also focusing on particular areas of the project.
 
 ## Mission Statement
 To ensure the quality, stability and long-term maintenance of the Linux kernel

--- a/kernelci.org/content/en/docs/org/board.md
+++ b/kernelci.org/content/en/docs/org/board.md
@@ -3,7 +3,7 @@ title: "Advisory Board"
 date: 2021-09-03
 draft: false
 description: "Representatives from each member organization"
-weight: 1
+weight: 2
 aliases:
   - "/docs/team/board"
 ---

--- a/kernelci.org/content/en/docs/org/tsc.md
+++ b/kernelci.org/content/en/docs/org/tsc.md
@@ -3,7 +3,7 @@ title: "Technical Steering Committee"
 date: 2021-09-03
 draft: false
 description: "Core developers and maintainers"
-weight: 2
+weight: 3
 aliases:
   - "/docs/team/tsc"
 ---

--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -32,3 +32,25 @@ potentially a new design from scratch using modern web technology.
 * [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan`
 * [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) - `glunardi`
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`
+
+## Sysadmin
+
+The KernelCI common infrastructure requires some regular maintenance to keep
+web servers, databases and Cloud services up and running.  This does not
+include any test lab other than some Kubernetes clusters as hardware platforms
+are maintained by separate companies and individuals.  Members of the sysadmin
+working group have admin rights on most of the KernelCI systems, wherever
+applicable.  This group has a large overlap with [service
+maintainers](tsc/#service-maintainers), it's merely a way to facilitate
+operations and ensure maintenance is taking place.
+
+**Workboard:** https://github.com/orgs/kernelci/projects/7
+
+**Team:**
+
+* [Corentin Labbe](mailto:<clabbe@baylibre.com>) - `montjoie`
+* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
+* [Kevin Hilman](mailto:<khilman@baylibre.com>) - `khilman`
+* [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`
+* [Michał Gałka](mailto:<michal.galka@collabora.com>) - `mgalka`
+* [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`

--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -1,0 +1,34 @@
+---
+title: "Working groups"
+date: 2022-03-15
+description: "KernelCI Working Groups"
+weight: 4
+---
+
+Working groups are small teams of people focusing on a particular aspect of the
+project.  Each group typically relies on a monthly meeting and a GitHub
+workboard to keep track of things.
+
+## Web dashboard
+
+As KernelCI keeps growing, and based on the results of the [2020 Community
+Survey](http://localhost:1313/blog/posts/2020/07/09/), a new web dashboard is
+necessary in order to achieve the goals set by the project.  Several attempts
+have been made in the past to replace the current one on
+[linux.kernelci.org](https://linux.kernelci.org) but none of them actually
+provided a viable alternative.  We've since started gathering ideas from a
+range of users in order to produce user stories and get a clear understanding
+of what is required.  Based on this, we'll then be looking for technical
+solutions including existing frameworks, dashboards used by other projects and
+potentially a new design from scratch using modern web technology.
+
+**Workboard:** https://github.com/orgs/kernelci/projects/4
+
+**Team:**
+
+* [Alexandra Pereira](mailto:<alexandra.pereira@collabora.com>) - `apereira`
+* [Greg Kroah-Hartman](mailto:<gregkh@linuxfoundation.org>) - `gregkh`
+* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
+* [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan`
+* [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) - `glunardi`
+* [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`


### PR DESCRIPTION
Add a page in the Organization section about working groups, with Web Dashboard and Sysadmin to start with.