### PR TITLE
kernelci.org docs: fix staging kernel branch names

### DIFF
--- a/kernelci.org/content/en/docs/instances/staging.md
+++ b/kernelci.org/content/en/docs/instances/staging.md
@@ -80,7 +80,7 @@ There is a timer on the staging.kernelci.org server which starts a job every
 1. update the `kernelci-backend` service using Ansible from [`kernelci-backend-config`](https://github.com/kernelci/kernelci-backend-config) with the staging branch
 1. update [staging branch for `kernelci-frontend`](https://github.com/kernelci/kernelci-frontend/tree/staging.kernelci.org)
 1. update the `kernelci-frontend` service using Ansible from [`kernelci-frontend-config`](https://github.com/kernelci/kernelci-frontend-config) with the staging branch
-1. create and push a `staging.kernelci.org` branch with a tag to the [KernelCI
+1. create and push a `staging-mainline` branch with a tag to the [KernelCI
    kernel repo](https://github.com/kernelci/linux)
 1. trigger a monitor job in Jenkins with the `kernelci_staging` build config
 

--- a/kernelci.org/content/en/docs/instances/staging.md
+++ b/kernelci.org/content/en/docs/instances/staging.md
@@ -80,8 +80,8 @@ There is a timer on the staging.kernelci.org server which starts a job every
 1. update the `kernelci-backend` service using Ansible from [`kernelci-backend-config`](https://github.com/kernelci/kernelci-backend-config) with the staging branch
 1. update [staging branch for `kernelci-frontend`](https://github.com/kernelci/kernelci-frontend/tree/staging.kernelci.org)
 1. update the `kernelci-frontend` service using Ansible from [`kernelci-frontend-config`](https://github.com/kernelci/kernelci-frontend-config) with the staging branch
-1. create and push a `staging-mainline` branch with a tag to the [KernelCI
-   kernel repo](https://github.com/kernelci/linux)
+1. pick a kernel tree between mainline, stable and next
+1. create and push a `staging-${tree}` branch with a tag to the [KernelCI kernel repo](https://github.com/kernelci/linux)
 1. trigger a monitor job in Jenkins with the `kernelci_staging` build config
 
 The last step should cause the monitor job to detect that the staging kernel


### PR DESCRIPTION
Improve the staging documentation by fixing the kernel branch names and documenting the 3 possible trees being used.

Replaces #109 