### PR TITLE
kernelci.org: docs: change monitor job timer to 1h

### DIFF
--- a/kernelci.org/content/en/docs/instances/production.md
+++ b/kernelci.org/content/en/docs/instances/production.md
@@ -155,12 +155,14 @@ the main kernelci.org server.
    solution is to set the scheduler manually.
 
      * Log in to Jenkins on https://bot.kernelci.org
-     * Go to `kernel-tree-monitor` job configuration page at https://bot.kernelci.org/job/kernel-tree-monitor/configure
+     * Go to `kernel-tree-monitor` job configuration page at
+       https://bot.kernelci.org/job/kernel-tree-monitor/configure
      * In __Build Triggers__ section choose __Build periodically__
-     * Paste the following settings to the __Schedule__ text box
+     * Paste the following settings to the __Schedule__ text box to have the
+       monitor job run every hour:
 
      ```
-     H H/2 * * *
+     H * * * *
      ```
 
-     * Save settings by clicking __Save__ button 
+     * Save settings by clicking __Save__ button


### PR DESCRIPTION
Tweak the documentation about production update procedure to set the
monitor timer to 1h rather than 2h.  Some recent rework means the
build trigger jobs won't pile up in the queue if the monitor is run
more often.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>