### PR TITLE
Add docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,17 @@ $ sudo apt install -y git-lfs
 $ git-lfs fetch
 $ git-lfs checkout
 $ git submodule update --init --recursive
+```
+
+Then to start the server:
+```sh
 $ docker run -v $PWD:/src -p 1313:1313 klakegg/hugo:0.80.0-ext-debian server -D
+```
+
+Alternatively, this can be started with `docker-compose`:
+
+```sh
+docker-compose up
 ```
 
 Then open http://localhost:1313 in your browser.

--- a/kernelci.org/docker-compose.yaml
+++ b/kernelci.org/docker-compose.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright (C) 2022 Collabora Limited
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+
+version: '3'
+services:
+
+  kernelci.org:
+    container_name: 'kernelci.org'
+    image: 'klakegg/hugo:0.80.0-ext-debian'
+    volumes:
+      - '.:/src'
+    ports:
+      - '1313:1313'
+    command:
+      - 'server'
+      - '-D'

--- a/kernelci.org/docker-compose.yaml
+++ b/kernelci.org/docker-compose.yaml
@@ -15,4 +15,3 @@ services:
       - '1313:1313'
     command:
       - 'server'
-      - '-D'


### PR DESCRIPTION
Add a basic `docker-compose.yaml` file to start the local development server with all parameters and volumes already defined.