### PR TITLE
kernelci.org: add blog post about sysadmin RFP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@ kernelci.org/content/en/blog/posts/2020/08/21/kcidb_object_relations.svg filter=
 kernelci.org/content/en/blog/posts/2020/08/21/kcidb_object_submitting.gif filter=lfs diff=lfs merge=lfs -text
 kernelci.org/content/en/blog/posts/2021/03/16/looking-back-looking-forward.png filter=lfs diff=lfs merge=lfs -text
 kernelci.org/static/image/kernelci-horizontal-color.png filter=lfs diff=lfs merge=lfs -text
+kernelci.org/content/en/blog/posts/2022/rfp-sysadmin/RFP-Sysadmin-Maintenance-2022-v3.pdf filter=lfs diff=lfs merge=lfs -text

--- a/kernelci.org/content/en/blog/posts/2022/rfp-sysadmin/RFP-Sysadmin-Maintenance-2022-v3.pdf
+++ b/kernelci.org/content/en/blog/posts/2022/rfp-sysadmin/RFP-Sysadmin-Maintenance-2022-v3.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9342d1ed755bc93d7757dfebee3dcb0e144d83655eb6bc533c737e73c94bac1
+size 110247

--- a/kernelci.org/content/en/blog/posts/2022/rfp-sysadmin/index.md
+++ b/kernelci.org/content/en/blog/posts/2022/rfp-sysadmin/index.md
@@ -1,0 +1,38 @@
+---
+date: 2022-06-27
+title: "Request for Proposals: Sysadmin Maintenance 2022"
+linkTitle: "RFP: Sysadmin 2022"
+author: Guillaume Tucker
+description: >
+  Request for Proposal for KernelCI sysadmin maintenance
+---
+
+## Summary
+
+The KernelCI project relies on a number of web services which need constant
+maintenance.  These include databases, automation tools and web dashboards for
+several instances.  Some are hosted on dedicated virtual machines (VMs), others
+in the cloud.  This Request for Proposals seeks to extend the current team with
+dedicated sysadmins to ensure the maintenance of these services is being
+carried out to guarantee a good quality of service.  Additionally, some
+improvements can be made to reduce the maintenance burden.
+
+## Budget
+
+We’re expecting quotations for this work package to range between 15,000 and
+30,000 USD depending on the contents of the proposal and for a period of six
+months. Longer sysadmin time available and extra improvements can justify a
+higher price.  Payments would be made via the Linux Foundation using the
+project’s own budget.
+
+## Sending proposals
+
+Please take a look at the full
+[RFP-Sysadmin-Maintenance-2022-v3.pdf](RFP-Sysadmin-Maintenance-2022-v3.pdf)
+document for all the details. Proposals should be sent by email directly to the
+[project members](mailto:kernelci-members@groups.io).
+
+The deadline for responding to this RFP is **8th August 2022**, six weeks after
+it has been made public. Then the KernelCI Advisory Board of Members will vote
+on the **24th August 2022**. Exact dates might be subject to change in case of
+a major practical issue or unavailability of voting members.


### PR DESCRIPTION
Add a small blog post to introduce the Sysadmin Maintenance 2022 RFP with a link to the PDF hosted directly on the website.
