### PR TITLE
doc: drop draft attribute

### DIFF
--- a/kernelci.org/content/en/docs/_index.md
+++ b/kernelci.org/content/en/docs/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Documentation"
 date: 2021-02-10T11:48:13Z
-draft: true
 menu: main
 ---

--- a/kernelci.org/content/en/docs/admin/_index.md
+++ b/kernelci.org/content/en/docs/admin/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Admin"
 date: 2021-04-22T08:41:29Z
-draft: true
 description: "KernelCI Administrator guide"
 ---
 

--- a/kernelci.org/content/en/docs/admin/secrets.md
+++ b/kernelci.org/content/en/docs/admin/secrets.md
@@ -1,7 +1,6 @@
 ---
 title: "Secrets"
 date: 2021-09-03
-draft: false
 description: "KernelCI project encrypted files"
 ---
 

--- a/kernelci.org/content/en/docs/architecture.md
+++ b/kernelci.org/content/en/docs/architecture.md
@@ -1,7 +1,6 @@
 ---
 title: "Architecture"
 date: 2021-08-06
-draft: false
 description: "KernelCI architecture"
 weight: 1
 ---

--- a/kernelci.org/content/en/docs/bisection.md
+++ b/kernelci.org/content/en/docs/bisection.md
@@ -1,7 +1,6 @@
 ---
 title: "Bisection"
 date: 2021-02-10T11:41:21Z
-draft: true
 description: "KernelCI Automated Bisection support"
 ---
 

--- a/kernelci.org/content/en/docs/faq.md
+++ b/kernelci.org/content/en/docs/faq.md
@@ -1,7 +1,6 @@
 ---
 title: "FAQ"
 date: 2021-03-30T22:02:52Z
-draft: true
 description: Frequently asked questions
 ---
 

--- a/kernelci.org/content/en/docs/instances/_index.md
+++ b/kernelci.org/content/en/docs/instances/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Instances"
 date: 2021-07-21T21:00:00Z
-draft: false
 description: "KernelCI public instances"
 weight: 2
 ---

--- a/kernelci.org/content/en/docs/instances/local.md
+++ b/kernelci.org/content/en/docs/instances/local.md
@@ -1,7 +1,6 @@
 ---
 title: "Local (Dev setup)"
 date: 2021-08-12T10:15:37Z
-draft: true
 description: "How to set up a local KernelCI instance"
 ---
 
@@ -74,7 +73,7 @@ touch host_vars/kci-vm
 - Edit `host_vars/kci-vm` with your favorite text editor and put content there:
 
 ```ini
-hostname: kci-vm 
+hostname: kci-vm
 role: production
 certname: kci-vm
 storage_certname: kci-vm

--- a/kernelci.org/content/en/docs/instances/production.md
+++ b/kernelci.org/content/en/docs/instances/production.md
@@ -1,7 +1,6 @@
 ---
 title: "Production"
 date: 2021-07-27T19:30:00Z
-draft: false
 description: "How linux.kernelci.org works"
 ---
 

--- a/kernelci.org/content/en/docs/instances/staging.md
+++ b/kernelci.org/content/en/docs/instances/staging.md
@@ -1,7 +1,6 @@
 ---
 title: "Staging"
 date: 2021-07-22T08:30:00Z
-draft: false
 description: "How staging.kernelci.org works"
 ---
 

--- a/kernelci.org/content/en/docs/labs/_index.md
+++ b/kernelci.org/content/en/docs/labs/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Labs"
 date: 2021-02-10T20:24:29Z
-draft: true
 description: "Using test labs with KernelCI"
 ---

--- a/kernelci.org/content/en/docs/labs/lava.md
+++ b/kernelci.org/content/en/docs/labs/lava.md
@@ -1,7 +1,6 @@
 ---
 title: "LAVA"
 date: 2021-08-04
-draft: false
 description: "Using LAVA with KernelCI"
 ---
 

--- a/kernelci.org/content/en/docs/org/_index.md
+++ b/kernelci.org/content/en/docs/org/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Organization"
 date: 2021-09-03
-draft: false
 description: "KernelCI project organization"
 weight: 3
 aliases:

--- a/kernelci.org/content/en/docs/org/board.md
+++ b/kernelci.org/content/en/docs/org/board.md
@@ -1,7 +1,6 @@
 ---
 title: "Advisory Board"
 date: 2021-09-03
-draft: false
 description: "Representatives from each member organization"
 weight: 2
 aliases:

--- a/kernelci.org/content/en/docs/org/members.md
+++ b/kernelci.org/content/en/docs/org/members.md
@@ -1,7 +1,6 @@
 ---
 title: "Members"
 date: 2021-09-07
-draft: false
 description: "Member companies who fund the KernelCI project"
 weight: 1
 ---

--- a/kernelci.org/content/en/docs/org/tsc.md
+++ b/kernelci.org/content/en/docs/org/tsc.md
@@ -1,7 +1,6 @@
 ---
 title: "Technical Steering Committee"
 date: 2021-09-03
-draft: false
 description: "Core developers and maintainers"
 weight: 3
 aliases:

--- a/kernelci.org/content/en/docs/tests/_index.md
+++ b/kernelci.org/content/en/docs/tests/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Tests"
 date: 2021-08-04
-draft: false
 description: KernelCI Tests
 weight: 3
 ---

--- a/kernelci.org/content/en/docs/tests/howto.md
+++ b/kernelci.org/content/en/docs/tests/howto.md
@@ -1,7 +1,6 @@
 ---
 title: "How-To"
 date: 2021-08-06
-draft: false
 description: "How to add a new native test suite"
 weight: 1
 ---

--- a/kernelci.org/content/en/docs/tests/kselftest.md
+++ b/kernelci.org/content/en/docs/tests/kselftest.md
@@ -1,7 +1,6 @@
 ---
 title: "kselftest"
 date: 2021-08-05
-draft: false
 description: "Native tests: kselftest"
 weight: 2
 ---

--- a/kernelci.org/content/en/docs/tests/ltp.md
+++ b/kernelci.org/content/en/docs/tests/ltp.md
@@ -1,7 +1,6 @@
 ---
 title: "LTP"
 date: 2021-08-05
-draft: false
 description: "Native tests: LTP"
 weight: 3
 ---


### PR DESCRIPTION
Drop the draft attribute as it's not used for anything and pages
randomly had it set to true or false.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>