### PR TITLE
kernelci.org: fix typo in TSC page

### DIFF
--- a/kernelci.org/content/en/docs/org/tsc.md
+++ b/kernelci.org/content/en/docs/org/tsc.md
@@ -179,7 +179,7 @@ those tests and getting their results into the database.
 
 ### Native builds
 
-Just like tests, kernel builds orchestrated on kerlci.org are called the
+Just like tests, kernel builds orchestrated on kernelci.org are called the
 *native* KernelCI builds.
 
 * Maintainer: `broonie`


### PR DESCRIPTION
Fix the typo: s/kerlci/kernelci/.

Signed-off-by: Tzung-Bi Shih <tzungbi@kernel.org>