### PR TITLE
kernelci.org: fix typos in sysadmin blog post

### DIFF
--- a/kernelci.org/content/en/blog/posts/2022/sysadmin-onboard/index.md
+++ b/kernelci.org/content/en/blog/posts/2022/sysadmin-onboard/index.md
@@ -1,23 +1,25 @@
 ---
 date: 2022-09-28
-title: "Now KernelCI has a dedicated Sysadmin!"
-linkTitle: "Now KernelCI has a dedicated Sysadmin!"
+title: "Now KernelCI has a dedicated SysAdmin!"
+linkTitle: "Now KernelCI has a dedicated SysAdmin!"
 author: Gustavo Padovan
 description: >
-  The KernelCI.org project welcomes Vince Hille as SysAdmin
+  The KernelCI.org project welcomes Vince Hillier as SysAdmin
 ---
 
-Recently, we posted about the [Request For Proposals](../rfp-sysadmin/) to undertake SysAdmin tasks
-for KernelCI.org. That process is now complete, and we are delighted to announce
-that the KernelCI advisory board hired Vince Hille from Revenni Inc to conduct
-the work.
+Recently, we posted about the [Request For
+Proposals](/blog/posts/2022/rfp-sysadmin/) to undertake SysAdmin tasks for
+KernelCI.org. That process is now complete, and we are delighted to announce
+that the KernelCI advisory board hired Vince Hillier from Revenni Inc to
+conduct the work.
 
-Vince will worked together with the Technical Steering Committee(TSC) of the project to
-maintain and improve the current project infrastructure. As KernelCI.org scales with
-more kernels being built and more tests being run, we definitely need help to keep 
-our systems stable and up-to-date.
+Vince will work together with the Technical Steering Committee
+([TSC](/docs/org/tsc/)) to maintain and improve the current project
+infrastructure. As KernelCI.org scales with more kernels being built and more
+tests being run, we definitely need help to keep our systems stable and up to
+date.
 
 The KernelCI project relies on a number of web services which need constant
 maintenance. These include databases, automation tools and web dashboards for
-several instances. Some are hosted on dedicated virtual machines (VMs), others
-in the cloud.
+several [instances](/docs/instances/). Some are hosted on dedicated virtual
+machines (VMs), others in the cloud.


### PR DESCRIPTION
Fix typos in Vince Hillier's name as well as a few other glitches in the blog post about our new SysAdmin.  Use full URIs for relative links so they work regardless of the current blog URL and add some links to the TSC and instances documentation pages.

Fixes: 3f66b646a770 ("blog: add post to announce new SysAdmin")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>