### PR TITLE
kernelci.org: tsc: add section about TSC rules

### DIFF
--- a/kernelci.org/content/en/docs/org/tsc.md
+++ b/kernelci.org/content/en/docs/org/tsc.md
@@ -1,6 +1,6 @@
 ---
 title: "Technical Steering Committee"
-date: 2021-09-23
+date: 2021-11-10
 description: "KernelCI core developers and maintainers"
 weight: 3
 aliases:
@@ -9,12 +9,12 @@ aliases:
 
 The Technical Steering Committee (TSC) is a team of people who are responsible
 for keeping the KernelCI project in a good shape and driving its development.
-
-The rules for adding or removing members from the TSC are defined in the LF
-project [charter](/files/KernelCI_Project_Technical_Charter_20181107.pdf).
-Typically, major contributors eventually become members and those who have
-stopped contributing for an extended period of time may be removed.  This is
-done in agreement with the TSC and the AB.
+The [rules](#rules) are based on the LF [project
+charter](/files/KernelCI_Project_Technical_Charter_20181107.pdf).  Typically,
+major contributors eventually become members and those who have stopped
+contributing for an extended period of time may be removed.  This is done in
+agreement with the TSC and the AB.  The TSC may vote to make decisions when
+there is no consensus or when a formal procedure is required.
 
 ## Members
 
@@ -41,3 +41,39 @@ used instead.
 
 The TSC also meet monthly online to discuss current topics and make decisions
 including votes when necessary.
+
+## Rules
+
+### Votes
+
+Most decisions are reached by consensus and don't require a vote.  Decisions
+that always require a vote are when adding or removing TSC members and making
+proposals to the board.  The results of the votes should be archived and as
+such they provide a way to keep a formal trace of decisions being made.
+
+> *Note* The archiving process for TSC votes hasn't been formalised yet.  Past
+> votes should be retroactively archived when this has been put in place.  They
+> should appear in a sub-section of this documentation section.
+
+Conditions for making a successful vote and determining its outcome are defined
+in the [project
+charter](/files/KernelCI_Project_Technical_Charter_20181107.pdf) in section
+*3. TSC Voting*.  Votes done in a live meeting require 50% of the TSC to be
+voting and a majority among the members attending.  Votes done by email or
+other deferred channel require a majority among all of the TSC members.
+
+### Members
+
+Current members of the TSC may suggest new people to be added.  This should
+then go through a vote to keep a trace of it and prevent a single organisation
+from taking over the TSC.
+
+Likewise, members of the TSC may suggest that a member be removed which should
+result in a vote.  Members who have not been active for over a year should be
+notified and considered for removal from TSC in order to keep the list
+up-to-date with the reality of the project.  Active members are typically
+expected to:
+
+* attend meetings (monthly)
+* participate in votes
+* make some form of positive contribution to the project


### PR DESCRIPTION
Add a section to detail the TSC rules in terms of votes and members. This is based on the project charter document and adds more context as to how this should work in practice.

A sub-section should be created as a follow-up to archive the results of all the votes carried out by the TSC.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>