### PR TITLE
Update mailing list address and IRC network references

### DIFF
--- a/kernelci.org/content/en/about/_index.html
+++ b/kernelci.org/content/en/about/_index.html
@@ -75,8 +75,8 @@ menu: main
 
 {{< blocks/section color="white">}}
 
-{{% blocks/feature icon="fa-paper-plane" title="Mailing list" url="https://groups.io/g/kernelci/topics" %}}
-Send an email to <a href="mailto:kernelci@groups.io">kernelci@groups.io</a>
+{{% blocks/feature icon="fa-paper-plane" title="Mailing list" url="https://lore.kernel.org/kernelci/" %}}
+Send an email to <a href="mailto:kernelci@lists.linux.dev">kernelci@lists.linux.dev</a>
 {{% /blocks/feature %}}
 
 {{% blocks/feature icon="fa-comment-dots" title="IRC" %}}

--- a/kernelci.org/content/en/blog/posts/2020/05/11/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/05/11/index.html
@@ -94,7 +94,7 @@ public (details below.)</p>
 </ul>
 <p>Engage</p>
 <ul>
-  <li>IRC: #kernelci on Freenode</li>
+  <li>IRC: #kernelci on libera.chat</li>
   <li>Weekly technical call: Tuesdays: 16h-17h UTC</li>
   <li>Code: 100% open-source.  All repos here:
     <a href="https://github.com/kernelci/">https://github.com/kernelci/ </a></li>

--- a/kernelci.org/content/en/blog/posts/2020/07/09/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/07/09/index.html
@@ -21,7 +21,7 @@ opening it again until the end of August using the same
 <a href="https://forms.gle/Y5iuyLXgQr2y3SrF6">Google Form</a>. If you have any
 other comments or questions, please feel free to send them to the
 <a href="mailto:kernelci@lists.linux.dev">kernelci@lists.linux.dev</a> mailing
-list or get in touch on the IRC #kernelci Freenode channel.</p>
+list or get in touch on the IRC #kernelci libera.chat channel.</p>
 
 <h2>Main Takeaway: Test the Patches</h2>
 <p>A few things came out very clearly from the survey and we are taking them

--- a/kernelci.org/content/en/blog/posts/2020/07/09/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/07/09/index.html
@@ -20,8 +20,8 @@ will be taken into account.</p>
 opening it again until the end of August using the same
 <a href="https://forms.gle/Y5iuyLXgQr2y3SrF6">Google Form</a>. If you have any
 other comments or questions, please feel free to send them to the
-<a href="mailto:kernelci@groups.io">kernelci@groups.io</a> mailing list or get
-in touch on the IRC #kernelci Freenode channel.</p>
+<a href="mailto:kernelci@lists.linux.dev">kernelci@lists.linux.dev</a> mailing
+list or get in touch on the IRC #kernelci Freenode channel.</p>
 
 <h2>Main Takeaway: Test the Patches</h2>
 <p>A few things came out very clearly from the survey and we are taking them

--- a/kernelci.org/content/en/blog/posts/2020/08/21/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/08/21/index.html
@@ -423,10 +423,10 @@ to internal objects.</p>
 it over to us. There's no handshake, synchronization, or object ID allocation.
 To send it you need to specify an authentication key and the destination, both
 of which we supply you with. Contact us at
-<a href="mailto:kernelci@groups.io">kernelci@groups.io</a>, or the #kernelci
-channel on <a href="https://freenode.net/">freenode.net</a> to get yours. You
-can use either the command-line tool, or the Python 3 library to submit your
-reports.</p>
+<a href="mailto:kernelci@lists.linux.dev">kernelci@lists.linux.dev</a>, or the
+#kernelci channel on <a href="https://freenode.net/">freenode.net</a> to get
+yours. You can use either the command-line tool, or the Python 3 library to
+submit your reports.</p>
 
 <p>In practice, a command-line submission could look like this:</p>
 
@@ -463,4 +463,5 @@ have.</p>
 <h2>How to help</h2>
 <p>Send us your kernel testing reports, and volunteer to receive email
 notifications, join the development, share your ideas and report bugs! Write to
-<a href="mailto:kernelci@groups.io">kernelci@groups.io</a> if you want to help!</p>
+<a href="mailto:kernelci@lists.linux.dev">kernelci@lists.linux.dev</a> if you
+want to help!</p>

--- a/kernelci.org/content/en/blog/posts/2020/08/21/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/08/21/index.html
@@ -424,9 +424,8 @@ it over to us. There's no handshake, synchronization, or object ID allocation.
 To send it you need to specify an authentication key and the destination, both
 of which we supply you with. Contact us at
 <a href="mailto:kernelci@lists.linux.dev">kernelci@lists.linux.dev</a>, or the
-#kernelci channel on <a href="https://freenode.net/">freenode.net</a> to get
-yours. You can use either the command-line tool, or the Python 3 library to
-submit your reports.</p>
+#kernelci channel on libera.chat to get yours. You can use either the
+command-line tool, or the Python 3 library to submit your reports.</p>
 
 <p>In practice, a command-line submission could look like this:</p>
 

--- a/kernelci.org/content/en/docs/org/tsc.md
+++ b/kernelci.org/content/en/docs/org/tsc.md
@@ -34,8 +34,8 @@ respective email address and IRC nicknames:
 ## Communication
 
 For general discussions, the usual IRC channel `#kernelci` on libera.chat and
-the [`kernelci@groups.io`](mailto:<kernelci@groups.io>) mailing list can be
-used.  To contact only the TSC members directly, the
+the [`kernelci@lists.linux.dev`](mailto:<kernelci@lists.linux.dev>) mailing
+list can be used.  To contact only the TSC members directly, the
 [`kernelci-tsc@groups.io`](mailto:<kernelci-tsc@groups.io>) private list may be
 used instead.
 

--- a/kernelci.org/content/en/logo/_index.html
+++ b/kernelci.org/content/en/logo/_index.html
@@ -11,8 +11,8 @@ linkTitle: Logo
 
 <div class="row">
   <h3>
-    Help us keep the KernelCI visual identity consistent with these simple 
-    brand and logo guidelines. KernelCI is a registered trademark of The Linux 
+    Help us keep the KernelCI visual identity consistent with these simple
+    brand and logo guidelines. KernelCI is a registered trademark of The Linux
     Foundation.
   </h3>
 </div>
@@ -32,37 +32,37 @@ linkTitle: Logo
 
 <div class="col">
   <p>
-    These guidelines are available for download as: 
+    These guidelines are available for download as:
     <a href="kernelci_brand.svg">SVG</a> | <a href="kernelci_brand.pdf">PDF</a>
   </p>
   <p>
-    Logo files: 
+    Logo files:
   </p>
   <p>
-    KernelCI logo (color) <a href="files/kernelci-logo-color.svg">SVG</a> | 
-    <a href="files/kernelci-logo-color.png">PNG</a> 
+    KernelCI logo (color) <a href="files/kernelci-logo-color.svg">SVG</a> |
+    <a href="files/kernelci-logo-color.png">PNG</a>
   </p>
   </p>
-    KernelCI logo (black) <a href="files/kernelci-logo-black.svg">SVG</a> 
+    KernelCI logo (black) <a href="files/kernelci-logo-black.svg">SVG</a>
   </p>
   </p>
-    KernelCI logo (white) <a href="files/kernelci-logo-white.svg">SVG</a> 
+    KernelCI logo (white) <a href="files/kernelci-logo-white.svg">SVG</a>
   </p>
   <p>
-    By using the KernelCI trademark and logo, you agree to follow these 
-    guidelines as well as the trademark usage statement of The Linux 
-    Foundation. These guidelines apply to your use of the KernelCI trademark 
+    By using the KernelCI trademark and logo, you agree to follow these
+    guidelines as well as the trademark usage statement of The Linux
+    Foundation. These guidelines apply to your use of the KernelCI trademark
     and logo.
   </p>
   <p>
-    The KernelCI Advisory Board reserves the right to grant or deny any 
-    permission at its sole discretion and for any reason. If you have any 
-    questions about these guidelines, please contact 
-    <a href="mailto:kernelci@groups.io">kernelci@groups.io</a>.
+    The KernelCI Advisory Board reserves the right to grant or deny any
+    permission at its sole discretion and for any reason. If you have any
+    questions about these guidelines, please contact
+    <a href="mailto:kernelci-members@groups.io">kernelci-members@groups.io</a>.
   </p>
   <p>
-    KernelCI is a registered trademark of The Linux Foundation. For more 
-    information and statement, please visit 
+    KernelCI is a registered trademark of The Linux Foundation. For more
+    information and statement, please visit
     <a href="https://linuxfoundation.org/trademark-usage/">
       https://linuxfoundation.org/trademark-usage/
     </a>


### PR DESCRIPTION
Update all links to the mailing list to point to the new one kernelci@lists.linux.dev and all references to the `#kernelci` IRC channel on libera.chat rather than Freenode.