### PR TITLE
chromeos_changelog: add cherry & asurada/jacuzzi kernel uprev docs

### DIFF
--- a/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
@@ -1,6 +1,6 @@
 ---
 title: "ChromeOS image changelog"
-date: 2023-02-03
+date: 2023-04-25
 weight: 4
 ---
 
@@ -20,7 +20,7 @@ The latest version can be found either from the directory date name (e.g. `chrom
 
 For an up-to-date overview of current and planned releases, please visit the [schedule dashboard](https://chromiumdash.appspot.com/schedule).
 
-## Release 106
+## R106
 
 ### Repo manifest
 
@@ -48,37 +48,37 @@ Direct links for each supported board in this release are provided here for conv
 - [zork](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-zork/20221115.0/amd64/)
 
 ### Changes since previous version (R100)
-	- A custom repo manifest is used to build images which points to forked repositories.
-	- SElinux is now disabled in userspace, see issue https://github.com/kernelci/kernelci-core/issues/1372 .
-	- chromeos-kernel-upstream is used for Mediatek image builds.
+- A custom repo manifest is used to build images which points to forked repositories.
+- SElinux is now disabled in userspace, see issue https://github.com/kernelci/kernelci-core/issues/1372 .
+- chromeos-kernel-upstream is used for Mediatek image builds.
 
 ### Known divergences
 
 #### src/third-party/kernel/next
-	- Points to the [Mediatek Integration branch](https://gitlab.collabora.com/google/chromeos-kernel/-/tree/for-kernelci).
-	- Currently only used for cherry board builds because upstream support is still WIP.
+- Points to the [Mediatek Integration branch](https://gitlab.collabora.com/google/chromeos-kernel/-/tree/for-kernelci).
+- Currently only used for cherry board builds because upstream support is still WIP.
 
 #### src/third-party/kernel/upstream
-	- Based on v6.2.7 stable kernel release.
-	- `arch/arm64/configs/defconfig` was extended with Mediatek specific config fragments. In the future we might find a better way to fetch these for the upstream kernel builds.
-	- Backported and cherry-picked ~ 19 patches to enable Panfrost on mediatek. These will be dropped in future kernel versions.
+- Based on v6.2.7 stable kernel release.
+- `arch/arm64/configs/defconfig` was extended with Mediatek specific config fragments. In the future we might find a better way to fetch these for the upstream kernel builds.
+- Backported and cherry-picked ~ 19 patches to enable Panfrost on mediatek. These will be dropped in future kernel versions.
 
 #### src/third-party/chromiumos-overlay
-	- Disable selinux in the global profile for all boards.
-	- Upgrade mesa-panfrost to latest 22.3.3 for Mali valhall GPU support.
-	- Add USE flag to skip cr50 FW upgrades.
-	- Bump ebuilds for divergence in other components (kernel, minigbm).
+- Disable selinux in the global profile for all boards.
+- Upgrade mesa-panfrost to latest 22.3.3 for Mali valhall GPU support.
+- Add USE flag to skip cr50 FW upgrades.
+- Bump ebuilds for divergence in other components (kernel, minigbm).
 
 #### src/platform/minigbm
-	- Add patch to allow minigbm to work with panfrost BO ioctls. This works but needs significant changes before being sent upstream.
+- Add patch to allow minigbm to work with panfrost BO ioctls. This works but needs significant changes before being sent upstream.
 
 #### src/platform/initramfs
-	- Contains a backport of a commit which got upstreamed in [this CL](https://chromium-review.googlesource.com/c/chromiumos/platform/initramfs/+/4262007).
-	- This fork can be removed when upgrading to a newer ChromiumOS version containing the above commit.
+- Contains a backport of a commit which got upstreamed in [this CL](https://chromium-review.googlesource.com/c/chromiumos/platform/initramfs/+/4262007).
+- This fork can be removed when upgrading to a newer ChromiumOS version containing the above commit.
 
 #### src/overlays
-	- Added fix for broken upstream chipset-mt8183 virtual/opengles panfrost dependencies.
-	- Panfrost added as a graphics alternative for all Mediatek chipsets.
-	- Removed Mali G-57 empty job workaround firmware which is not required for upstream graphics.
-	- Instructed mt8183/8192 builds to use upstream kernel.
-	- Instructed mt8195 builds to use linux-next kernel / Mediatek Integration branch (see above).
+- Added fix for broken upstream chipset-mt8183 virtual/opengles panfrost dependencies.
+- Panfrost added as a graphics alternative for all Mediatek chipsets.
+- Removed Mali G-57 empty job workaround firmware which is not required for upstream graphics.
+- Instructed mt8183/8192 builds to use upstream kernel.
+- Instructed mt8195 builds to use linux-next kernel / Mediatek Integration branch (see above).

--- a/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
@@ -14,7 +14,19 @@ It is recommended to use the latest published image versions for each board from
 
 The latest version can be found either from the directory date name (e.g. `chromiumos-asurada/20230208.0`) or by the `distro_version` field in the `manifest.json` file, where for e.g. R106 is greater than R100.
 
+### ChromiumOS release documentation
+
+[This page](https://chromium.googlesource.com/chromiumos/docs/+/HEAD/releases.md) contains information on how ChromiumOS manages its releases, schedules, support windows and other such useful information.
+
+For an up-to-date overview of current and planned releases, please visit the [schedule dashboard](https://chromiumdash.appspot.com/schedule).
+
 ## Release 106
+
+### Repo manifest
+
+The following images have been built using [this manifest](https://github.com/kernelci/kernelci-core/blob/chromeos/config/rootfs/chromiumos/cros-snapshot-release-R106-15054.B.xml). The [repo tool](https://code.google.com/archive/p/git-repo/) can fetch the sources specified in the manifest file.
+
+Specific instructions on how to fetch and build ChromiumOS from a manifest file can be found in the [developer guide](https://chromium.googlesource.com/chromiumos/docs/+/main/developer_guide.md).
 
 ### Supported boards
 

--- a/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
@@ -21,6 +21,7 @@ The latest version can be found either from the directory date name (e.g. `chrom
 Direct links for each supported board in this release are provided here for convenience:
 - [amd64-generic](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20221102.0/arm64)
 - [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20230208.0/arm64)
+- [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20230330.0/arm64)
 - [coral](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20221026.0/amd64)
 - [dedede](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20221113.0/amd64/)
 - [grunt](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20221028.0/amd64/)
@@ -41,8 +42,12 @@ Direct links for each supported board in this release are provided here for conv
 
 ### Known divergences
 
+#### src/third-party/kernel/next
+	- Points to the [Mediatek Integration branch](https://gitlab.collabora.com/google/chromeos-kernel/-/tree/for-kernelci).
+	- Currently only used for cherry board builds because upstream support is still WIP.
+
 #### src/third-party/kernel/upstream
-	- Based on latest v6.2 kernel release.
+	- Based on v6.2.7 stable kernel release.
 	- `arch/arm64/configs/defconfig` was extended with Mediatek specific config fragments. In the future we might find a better way to fetch these for the upstream kernel builds.
 	- Backported and cherry-picked ~ 19 patches to enable Panfrost on mediatek. These will be dropped in future kernel versions.
 
@@ -55,8 +60,13 @@ Direct links for each supported board in this release are provided here for conv
 #### src/platform/minigbm
 	- Add patch to allow minigbm to work with panfrost BO ioctls. This works but needs significant changes before being sent upstream.
 
+#### src/platform/initramfs
+	- Contains a backport of a commit which got upstreamed in [this CL](https://chromium-review.googlesource.com/c/chromiumos/platform/initramfs/+/4262007).
+	- This fork can be removed when upgrading to a newer ChromiumOS version containing the above commit.
+
 #### src/overlays
 	- Added fix for broken upstream chipset-mt8183 virtual/opengles panfrost dependencies.
 	- Panfrost added as a graphics alternative for all Mediatek chipsets.
 	- Removed Mali G-57 empty job workaround firmware which is not required for upstream graphics.
 	- Instructed mt8183/8192 builds to use upstream kernel.
+	- Instructed mt8195 builds to use linux-next kernel / Mediatek Integration branch (see above).


### PR DESCRIPTION
This is the documentation counterpart of the kernelci-core PR: 

https://github.com/kernelci/kernelci-core/pull/1832

We need to wait until the kernelci-core PR lands and we have images on public storage before landing this (I will update the TODO: add link).