### PR TITLE
GitHub: add issue template for user stories

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,27 @@
+---
+name: User Story
+about: Formatted user story for UX improvement
+title: "<User persona>: <Topic>"
+assignees: ''
+
+---
+
+*Please replace the words in capital letters below with your own:*
+
+As USER PERSONA, I want to USER INTENT so USER BENEFIT.
+
+*For example: As a kernel hacker, I want to be notified about bugs so I can fix them.*
+
+## Background
+
+*Please provide any extra information about this user story such as what led
+you to create it or any examples to illustrate it.*
+
+## Thank you!
+
+Thanks for adding a user story and contributing to improving KernelCI's user
+experience.  It should soon appear on the user experience
+[workboard](https://github.com/orgs/kernelci/projects/18/) so we can keep track
+of it.
+
+*This issue template was inspired by an [Atlassian article](https://www.atlassian.com/agile/project-management/user-stories) on user stories.*


### PR DESCRIPTION
Add an issue template for creating user stories for the User Experience workboard.