### PR TITLE
chromeos_changelog.md: Prepare notes to R111 release

### DIFF
--- a/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/instances/chromeos/chromeos_changelog.md
@@ -1,6 +1,6 @@
 ---
 title: "ChromeOS image changelog"
-date: 2023-04-25
+date: 2023-05-01
 weight: 4
 ---
 
@@ -20,34 +20,38 @@ The latest version can be found either from the directory date name (e.g. `chrom
 
 For an up-to-date overview of current and planned releases, please visit the [schedule dashboard](https://chromiumdash.appspot.com/schedule).
 
-## R106
+## R111
 
 ### Repo manifest
 
-The following images have been built using [this manifest](https://github.com/kernelci/kernelci-core/blob/chromeos/config/rootfs/chromiumos/cros-snapshot-release-R106-15054.B.xml). The [repo tool](https://code.google.com/archive/p/git-repo/) can fetch the sources specified in the manifest file.
+The following images have been built using [this manifest]https://github.com/kernelci/kernelci-core/blob/chromeos/config/rootfs/chromiumos/cros-snapshot-release-R111-15329.B.xml). The [repo tool](https://code.google.com/archive/p/git-repo/) can fetch the sources specified in the manifest file.
 
 Specific instructions on how to fetch and build ChromiumOS from a manifest file can be found in the [developer guide](https://chromium.googlesource.com/chromiumos/docs/+/main/developer_guide.md).
 
 ### Supported boards
 
 Direct links for each supported board in this release are provided here for convenience:
-- [amd64-generic](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20221102.0/arm64)
-- [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20230208.0/arm64)
-- [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20230330.0/arm64)
-- [coral](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20221026.0/amd64)
-- [dedede](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20221113.0/amd64/)
-- [grunt](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20221028.0/amd64/)
-- [hatch](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-hatch/20221027.0/amd64/)
-- [jacuzzi](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20230206.0/arm64/)
-- [nami](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-nami/20221120.0/amd64/)
-- [octopus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20221025.0/amd64/)
-- [rammus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-rammus/20221116.0/amd64/)
-- [sarien](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-sarien/20221111.0/amd64/)
-- [trogdor](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20230214.0/arm64/)
-- [volteer](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-volteer/20221115.0/amd64/)
-- [zork](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-zork/20221115.0/amd64/)
+- [amd64-generic](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-amd64-generic/20230417.0/amd64/)
+- [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20230414.0/arm64/)
+- [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20230412.0/arm64/)
+- [coral](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20230418.0/amd64/)
+- [dedede](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20230419.0/amd64)
+- [grunt](N/A)
+- [hatch](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-hatch/20230421.0/amd64/)
+- [jacuzzi](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20230423.0/arm64/)
+- [nami](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-nami/20230424.0/amd64/)
+- [octopus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20230425.0/amd64/)
+- [rammus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-rammus/20230426.0/amd64/)
+- [sarien](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-sarien/20230427.0/amd64/)
+- [trogdor](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20230427.0/arm64/)
+- [volteer](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-volteer/20230428.0/amd64/)
+- [zork](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-zork/20230429.0/amd64/)
 
-### Changes since previous version (R100)
+
+### Changes from R106 to R111
+- Extract CR50 firmware from the ChromeOS image for standalone flashing
+
+### Changes from R100 to R106
 - A custom repo manifest is used to build images which points to forked repositories.
 - SElinux is now disabled in userspace, see issue https://github.com/kernelci/kernelci-core/issues/1372 .
 - chromeos-kernel-upstream is used for Mediatek image builds.
@@ -66,7 +70,6 @@ Direct links for each supported board in this release are provided here for conv
 #### src/third-party/chromiumos-overlay
 - Disable selinux in the global profile for all boards.
 - Upgrade mesa-panfrost to latest 22.3.3 for Mali valhall GPU support.
-- Add USE flag to skip cr50 FW upgrades.
 - Bump ebuilds for divergence in other components (kernel, minigbm).
 
 #### src/platform/minigbm
@@ -82,3 +85,12 @@ Direct links for each supported board in this release are provided here for conv
 - Removed Mali G-57 empty job workaround firmware which is not required for upstream graphics.
 - Instructed mt8183/8192 builds to use upstream kernel.
 - Instructed mt8195 builds to use linux-next kernel / Mediatek Integration branch (see above).
+
+#### chromeos-base/chromeos-cr50
+- After building rootfs image CR50 firmware is forcefully extracted and removed from image, to avoid DUT hangs due CR50 firmware update
+during ChromeOS update.
+
+### Known issues (15/May/2023)
+- trogdor fails to run tests due TPM daemon problems
+- asurada reference kernel generates kernel oops after few seconds on boot
+- grunt image build fails due to broken kernel build


### PR DESCRIPTION
As we finished building rootfs images to R111 release, we need to publish updated information