### PR TITLE
Add UX Analysis RFP document and blog post

### DIFF
--- a/kernelci.org/content/en/blog/.gitattributes
+++ b/kernelci.org/content/en/blog/.gitattributes
@@ -1,0 +1,1 @@
+posts/2023/rfp-ux-analysis/RFP-UX-Analysis-2023-v2.pdf filter=lfs diff=lfs merge=lfs -text

--- a/kernelci.org/content/en/blog/posts/2023/rfp-ux-analysis/RFP-UX-Analysis-2023-v2.pdf
+++ b/kernelci.org/content/en/blog/posts/2023/rfp-ux-analysis/RFP-UX-Analysis-2023-v2.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5788872e556a169ae29b0c8309150defe2fa775558929cf193f90b1d709ef2d6
+size 112574

--- a/kernelci.org/content/en/blog/posts/2023/rfp-ux-analysis/index.md
+++ b/kernelci.org/content/en/blog/posts/2023/rfp-ux-analysis/index.md
@@ -1,0 +1,36 @@
+---
+date: 2023-05-29
+title: "Request for Proposals: UX Analysis 2023"
+linkTitle: "RFP: UX Analysis 2023"
+author: Guillaume Tucker
+description: >
+  Request for Proposal for KernelCI User Experience Analysis
+---
+
+The KernelCI project runs thousands of Linux kernel tests every day, generating
+a huge amount of data to help the community identify issues and trends. One way
+to communicate all this is through a bespoke web application that truly
+embodies the kernel community’s use cases. This Request For Proposals (RFP)
+aims to be an initial investigation to understand how the User Experience (UX)
+of the Web Dashboard could look like based on a set of user stories compiled by
+the KernelCI team.
+
+## Budget
+
+We're expecting vendors to submit a fixed-price proposal showing the total
+costs for the different phases they plan for the project. Optional or extra
+phases can be included as well. The vendors have autonomy to propose a process
+for the iterative feedback roadmap.  Payments would be made by the Linux
+Foundation using the project’s own budget.
+
+## Sending proposals
+
+Please take a look at the full
+[RFP-UX-Analysis-2023-v2.pdf](RFP-UX-Analysis-2023-v2.pdf)
+document for all the details. Proposals should be sent by email directly to the
+[project members](mailto:kernelci-members@groups.io).
+
+The deadline for responding to this RFP is **10th July 2023**, six weeks after
+it has been made public. Then the KernelCI Advisory Board of Members will vote
+on the **24th July 2023**. Exact dates might be subject to change in case of a
+major practical issue or unavailability of voting members.


### PR DESCRIPTION
Add the PDF file with the UX Analysis RFP and a blog post with a link and description.

Note: The date will need to be updated to `2023-05-29` before merging.  The current date is to be able to see the blog post on the staging website first.