### PR TITLE
Update working groups and set Denys as sysadmin lead

### DIFF
--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -65,9 +65,9 @@ operations and ensure maintenance is taking place.
 
 **Team:**
 
-* [Michał Gałka](mailto:<michal.galka@collabora.com>) - `mgalka` - Lead
+* [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat` - Lead
+* [Michał Gałka](mailto:<michal.galka@collabora.com>) - `mgalka`
 * [Corentin Labbe](mailto:<clabbe@baylibre.com>) - `montjoie`
-* [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat`
 * [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
 * [Kevin Hilman](mailto:<khilman@baylibre.com>) - `khilman`
 * [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`

--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -11,17 +11,6 @@ workboard to keep track of things.
 
 ## Web dashboard
 
-As KernelCI keeps growing, and based on the results of the [2020 Community
-Survey](http://localhost:1313/blog/posts/2020/07/09/), a new web dashboard is
-necessary in order to achieve the goals set by the project.  Several attempts
-have been made in the past to replace the current one on
-[linux.kernelci.org](https://linux.kernelci.org) but none of them actually
-provided a viable alternative.  We've since started gathering ideas from a
-range of users in order to produce user stories and get a clear understanding
-of what is required.  Based on this, we'll then be looking for technical
-solutions including existing frameworks, dashboards used by other projects and
-potentially a new design from scratch using modern web technology.
-
 **Workboard:** https://github.com/orgs/kernelci/projects/4
 
 **Team:**
@@ -33,7 +22,31 @@ potentially a new design from scratch using modern web technology.
 * [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) - `glunardi`
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`
 
+As KernelCI keeps growing, and based on the results of the [2020 Community
+Survey](http://localhost:1313/blog/posts/2020/07/09/), a new web dashboard is
+necessary in order to achieve the goals set by the project.  Several attempts
+have been made in the past to replace the current one on
+[linux.kernelci.org](https://linux.kernelci.org) but none of them actually
+provided a viable alternative.  We've since started gathering ideas from a
+range of users in order to produce user stories and get a clear understanding
+of what is required.  Based on this, we'll then be looking for technical
+solutions including existing frameworks, dashboards used by other projects and
+potentially a new design from scratch using modern web technology.
+
 ## SysAdmin
+
+**Workboard:** https://github.com/orgs/kernelci/projects/7
+
+**Team:**
+
+* [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat` - Lead
+* [Michał Gałka](mailto:<michal.galka@collabora.com>) - `mgalka`
+* [Corentin Labbe](mailto:<clabbe@baylibre.com>) - `montjoie`
+* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
+* [Kevin Hilman](mailto:<khilman@baylibre.com>) - `khilman`
+* [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`
+* [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`
+* [Vince Hillier](mailto:<vince@revenni.com>) - `vince`
 
 The KernelCI common infrastructure requires some regular maintenance to keep
 web servers, databases and Cloud services up and running.  This does not
@@ -60,16 +73,3 @@ cover the following items:
 This group has a large overlap with [service
 maintainers](tsc/#service-maintainers), it's merely a way to facilitate
 operations and ensure maintenance is taking place.
-
-**Workboard:** https://github.com/orgs/kernelci/projects/7
-
-**Team:**
-
-* [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat` - Lead
-* [Michał Gałka](mailto:<michal.galka@collabora.com>) - `mgalka`
-* [Corentin Labbe](mailto:<clabbe@baylibre.com>) - `montjoie`
-* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
-* [Kevin Hilman](mailto:<khilman@baylibre.com>) - `khilman`
-* [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`
-* [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`
-* [Vince Hillier](mailto:<vince@revenni.com>) - `vince`

--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -9,6 +9,13 @@ Working groups are small teams of people focusing on a particular aspect of the
 project.  Each group typically relies on a monthly meeting and a GitHub
 workboard to keep track of things.
 
+There should also be a lead to coordinate activities within each group, such
+as:
+
+* updating the workboard
+* preparing regular meeting agendas and keeping minutes
+* sharing regular reports with the TSC, board and public mailing list
+
 ## Web dashboard
 
 **Workboard:** https://github.com/orgs/kernelci/projects/4


### PR DESCRIPTION
As discussed and agreed, set Denys as the new SysAdmin working goup lead.

Also consolidate a bit the format of the page and add some typical tasks that should be part of the role of a working group lead.