### PR TITLE
docs: rename lab to runtime

### DIFF
--- a/kernelci.org/content/en/docs/labs/lava.md
+++ b/kernelci.org/content/en/docs/labs/lava.md
@@ -44,7 +44,7 @@ either manually or automatically via Jenkins.
    the description set to `kernel-ci-bisection-webhook` for automated
    bisection via Jenkins.
 1. Create a GitHub pull request to add your lab definition to
-   [`lab-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/main/config/core/lab-configs.yaml).
+   [`runtime-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/main/config/core/runtime-configs.yaml).
 1. Optionally, create another GitHub pull request to add device definitions in
    [`test-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/main/config/core/test-configs.yaml)
    if your lab has new device types not already covered by kernelci.org.

--- a/kernelci.org/content/en/docs/tests/howto.md
+++ b/kernelci.org/content/en/docs/tests/howto.md
@@ -153,7 +153,7 @@ test_configs:
 ```
 
 Each test plan also needs to be enabled to run in particular test labs in
-`lab-configs.yaml`.  Some labs such as the Collabora one allow all tests to be
+`runtime-configs.yaml`.  Some labs such as the Collabora one allow all tests to be
 run, and it contains the platforms listed above so no extra changes are
 required at this point.
 


### PR DESCRIPTION
As kernelci-core keep evolving we got some name changes that was missing in documentation. Renaming config files to represent new changes.

Fixes: https://github.com/kernelci/kernelci-project/issues/223