### PR TITLE
kernelci.org: move KCIDB part from Tests section to KCIDB

### DIFF
--- a/kernelci.org/content/en/docs/tests/_index.md
+++ b/kernelci.org/content/en/docs/tests/_index.md
@@ -43,20 +43,3 @@ directory
 * See [Contributing to kselftests](https://www.kernel.org/doc/html/latest/dev-tools/kselftest.html#contributing-new-tests) for instructions to add tests
 * You can find more details at the [kselftests wiki](https://kselftest.wiki.kernel.org)
 * Contact: Send questions to the mailing list **linux-kselftest@vger.kernel.org** or join **#linux-kselftest** IRC Channel on freenode
-
-## **CI Services contributing to KCIDB**
-
-The are a number of [CI Services in production](https://github.com/orgs/kernelci/projects/16) contributing to [KCIDB](https://kcidb.kernelci.org).
-
-## CKI
-
-This is Red Hat’s kernel CI service.  They run tests on a variety of
-enterprise class machines.  This service is used to test the kernel package
-in the Red Hat Enterprise Linux (RHEL) product.
-
-* See [Contributing to CKI](https://cki-project.org/docs/test-maintainers/onboarding/) for instructions to add tests
-* See [Contributing a submaintainer tree](https://cki-project.org/docs/user_docs/onboarding/) for instructions to test a git branch
-* You can find more details at the [cki-project.org](https://cki-project.org)
-* Contact: Send questions to **cki-project@redhat.com**
-
-


### PR DESCRIPTION
Remove the part of the Tests documentation section about KCIDB to add it in the KCIDB dedicated section instead.  This is to keep the Tests section only about kernel tests and not about any particular CI system.