### PR TITLE
kernelci.org: bring org section to the top

### DIFF
--- a/kernelci.org/content/en/docs/org/_index.md
+++ b/kernelci.org/content/en/docs/org/_index.md
@@ -2,7 +2,7 @@
 title: "Organization"
 date: 2021-09-03
 description: "KernelCI project organization"
-weight: 3
+weight: 1
 aliases:
   - "/docs/team/"
 ---


### PR DESCRIPTION
Bring the Organization section to the top of the table of contents by setting its weight to 1.  This provides some overview for the project so it makes sense to have there.