### PR TITLE
kernelci.org: chromeos_changelog.md: add note about hwprobe fix

### DIFF
--- a/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
@@ -57,6 +57,7 @@ Direct links for each supported board in this release are provided below for con
 * Updated separate patches for tpm2 flag where it is necessary
 * Added workaround for b/295364868 (orphan_files feature not supported by old kernels) by updating mke2fs.conf
 * Added workaround for PS1/command prompt
+* Backported fix for b/300303585. The fix was upstreamed starting with R119, after which KernelCI should drop it.
 
 ### Removed workarounds since previous version (R114)
 


### PR DESCRIPTION
This applies on top of https://github.com/kernelci/kernelci-project/pull/249

We backported a fix for b:300303585 which we also upstreamed in ChromeOS starting with R119.
