### PR TITLE
kernelci.org: move Core section to Legacy

### DIFF
--- a/kernelci.org/content/en/docs/core
+++ b/kernelci.org/content/en/docs/core
@@ -1,1 +1,0 @@
-../../../external/kernelci-core/doc

--- a/kernelci.org/content/en/docs/legacy/core
+++ b/kernelci.org/content/en/docs/legacy/core
@@ -1,0 +1,1 @@
+../../../../external/kernelci-core/doc


### PR DESCRIPTION
The Core section is really about the legacy configuration and command line tools.  Move it to the Legacy section so we can start new sections instead for the kci command line tool with TOML user settings and the new YAML pipeline configuration.