### PR TITLE
kernelci.org: remove DAG reference as it's just a plain tree

### DIFF
--- a/kernelci.org/content/en/blog/posts/2023/api-timeline/index.md
+++ b/kernelci.org/content/en/blog/posts/2023/api-timeline/index.md
@@ -56,10 +56,9 @@ user accounts so you can keep your own personal test data there, an abstraction
 for runtime environments so jobs can be run seamlessly in Docker, Kubernetes, a
 local shell, LAVA, [insert your own system here]... a new `kci` command line
 tool to rule them all and a unified Node schema to contain all the test data
-(revision, build, runtime test, regression...) in a tree or
-[DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph) to be precise.  But
-again, we'll go through all that later in more detail.  It's all based on
-requirements gathered from the community over the past few years.
+(revision, build, runtime test, regression...) in a tree.  But again, we'll go
+through all that later in more detail.  It's all based on requirements gathered
+from the community over the past few years.
 
 ## Timeline
 


### PR DESCRIPTION
Remove the link to the definition of a DAG in the API timeline blog post as the nodes form a simple tree structure which isn't really a DAG.  Nodes don't have multiple parents.

Fixes: e7e701974b9f ("kernelci.org: add blog post with API timeline")