### PR TITLE
kernelci.org: remove signature from Azure SAS token

### DIFF
--- a/kernelci.org/content/en/docs/admin/api.md
+++ b/kernelci.org/content/en/docs/admin/api.md
@@ -86,9 +86,9 @@ generated password:
 
   PASSWORD
 
-and your Azure Files token:
+and your personal Azure Files token:
 
-  ?sv=2022-11-02&ss=bfq&srt=sco&sp=rwdlacpitfx&se=2023-12-03T00:00:00Z&st=2023-09-04T00:00:00Z&spr=https&sig=g1lP2bLomBFr81hNnxi%2Bdi%2F8rvLI0aOZgzIgiZNDnIg%3D
+  ?sv=2022-11-02&ss=bfq&srt=sco&sp=<signature>
 
 Please take a look at the Early Access documentation page to update your API
 account with your own password and get started:


### PR DESCRIPTION
Remove the secret signature from the Azure SAS token mentioned in the documentation.  We've now decided to stop using a single public token for Early Access to remove the potential threat of users abusing it and uploading files not related to KernelCI etc.

Link: https://lore.kernel.org/kernelci/DM5PR0102MB34778BDC7668A45F8F55780180D3A@DM5PR0102MB3477.prod.exchangelabs.com/T/#u