### PR TITLE
legacy: chromeos: add R118 changelog

### DIFF
--- a/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
@@ -20,6 +20,63 @@ The latest version can be found either from the directory date name (e.g. `chrom
 
 For an up-to-date overview of current and planned releases, please visit the [schedule dashboard](https://chromiumdash.appspot.com/schedule).
 
+## R118
+
+### Repo manifest
+
+The following images have been built using [this manifest](https://raw.githubusercontent.com/kernelci/kernelci-core/chromeos/config/rootfs/chromiumos/cros-snapshot-release-R118-15604.B.xml). The [repo tool](https://code.google.com/archive/p/git-repo/) can fetch the sources specified in the manifest file.
+
+Specific instructions on how to fetch and build ChromiumOS from a manifest file can be found in the [developer guide](https://chromium.googlesource.com/chromiumos/docs/+/main/developer_guide.md).
+
+### Supported boards
+
+Direct links for each supported board in this release are provided below for convenience.
+| Board       | Kernels shipped in image | Kernels tested by KernelCI (replacing image kernels during boot) |
+|-------------|:------------:|:-------:|
+| [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20231106.0/arm64) | v6.4.x<br> + display patches<br> + panfrost | stable:linux-6.1.y |
+| [brya](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-brya/20231106.0/amd64) | default | stable:linux-6.1.y |
+| [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64) | linux-next 20230203<br> + mtk HW enablement patches<br> + panfrost | |
+| [coral](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20231106.0/amd64) | default | stable:linux-6.1.y |
+| [dedede](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [grunt](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [guybrush](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-guybrush/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [hatch](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-hatch/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [jacuzzi](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20231106.0/arm64/) | v6.4.x <br> + panfrost | stable:linux-6.1.y <br> next-integration-branch (for-kernelci) |
+| [nami](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-nami/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [octopus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20231106.0/amd64/) | chromeos-5.15 | stable:linux-6.1.y |
+| [puff](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-puff/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [rammus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-rammus/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [sarien](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-sarien/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [trogdor](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20231106.0/arm64/) | default | stable:linux-6.1.y |
+| [volteer](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-volteer/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [zork](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-zork/20231106.0/amd64/) | default | stable:linux-6.1.y |
+
+
+### New workarounds/patches since previous version (R116)
+
+#### minigbm:
+- Dropped mediatek backend in favor of drv_dumb backend, no more divergence for the platform/minigbm component.
+
+#### chromiumos-overlay:
+- Reworked the minigbm patch into a single two liner patch to activate drv_dumb
+- Droppped the bump to make chromeos-kernel-5_10 use our own forked 5.10 branch, in favor of the 5.10 branch shipped in R118 by CrOS upstream.
+- Fixed broken portage manifest for media-libs/cros-camera-libfs
+- Masked newer chromeos-chrome ebuild version which doesn't have a binpkg, to avoid unnecessarily long build times.
+- Bumped chromeos-installer ebuild as a result of forking the platform2 overlay.
+
+#### platform2:
+- Forked to disable failing installer tpm check, until a fix is  landed for b:291036452.
+
+#### graphics:
+- Backported patch from R119 to avoid a conflict, still need to keep this patch in R118
+
+#### board-overlays:
+- Forward ported the last remaining commit without conflicts. Will keep it for now but gradually will reduce its footprint as MTK SoCs start using the newer Google kernels with 6.6
+- Bumped octopus to 5.15 because tast fails with 4.14.
+
+#### third_party/kernel/v5.10:
+- Removed fork in favor of chromeos-kernel-5_10
+
 ## R116
 
 ### Repo manifest


### PR DESCRIPTION
ChromeOS testing on KernelCI is now happening using the latest LTS release R118.

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>