### PR TITLE
kernelci.org: update API account email with share name

### DIFF
--- a/kernelci.org/content/en/docs/admin/api.md
+++ b/kernelci.org/content/en/docs/admin/api.md
@@ -86,9 +86,13 @@ generated password:
 
   PASSWORD
 
-and your personal Azure Files token:
+Your personal Azure Files token is:
 
   ?sv=2022-11-02&ss=bfq&srt=sco&sp=<signature>
+
+and the associated share name is:
+
+  <share name>
 
 Please take a look at the Early Access documentation page to update your API
 account with your own password and get started:


### PR DESCRIPTION
Update the email template for sending out API user account details to clearly show the share name as it might not always be exactly the same as the username.