### PR TITLE
kernelci.org: legacy: chromeos: update documentation for kernels 6.6

### DIFF
--- a/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
@@ -33,23 +33,23 @@ Specific instructions on how to fetch and build ChromiumOS from a manifest file 
 Direct links for each supported board in this release are provided below for convenience.
 | Board       | Kernels shipped in image | Kernels tested by KernelCI (replacing image kernels during boot) |
 |-------------|:------------:|:-------:|
-| [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20231106.0/arm64) | v6.6.x<br> + panfrost | stable:linux-6.1.y |
-| [brya](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-brya/20231106.0/amd64) | default | stable:linux-6.1.y |
-| [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64) | v6.6.x<br> + 3 display patches<br> + panfrost | |
-| [coral](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20231106.0/amd64) | default | stable:linux-6.1.y |
-| [dedede](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [grunt](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [guybrush](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-guybrush/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [hatch](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-hatch/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [jacuzzi](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20231106.0/arm64/) | v6.6.x + panfrost | stable:linux-6.1.y <br> next-integration-branch (for-kernelci) |
-| [nami](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-nami/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [octopus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20231106.0/amd64/) | chromeos-5.15 | stable:linux-6.1.y |
-| [puff](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-puff/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [rammus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-rammus/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [sarien](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-sarien/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [trogdor](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20231106.0/arm64/) | default | stable:linux-6.1.y |
-| [volteer](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-volteer/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [zork](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-zork/20231106.0/amd64/) | default | stable:linux-6.1.y |
+| [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20231106.0/arm64) | v6.6.x<br> + panfrost | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [brya](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-brya/20231106.0/amd64) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64) | v6.6.x<br> + 3 display patches<br> + panfrost | stable:linux-6.6.y |
+| [coral](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20231106.0/amd64) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [dedede](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [grunt](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [guybrush](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-guybrush/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [hatch](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-hatch/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [jacuzzi](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20231106.0/arm64/) | v6.6.x + panfrost | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [nami](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-nami/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [octopus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20231106.0/amd64/) | chromeos-5.15 | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [puff](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-puff/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [rammus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-rammus/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [sarien](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-sarien/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [trogdor](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-trogdor/20231106.0/arm64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [volteer](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-volteer/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
+| [zork](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-zork/20231106.0/amd64/) | default | stable:linux-6.1.y <br> stable:linux-6.6.y |
 
 
 ### New workarounds/patches since previous version (R116)

--- a/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
+++ b/kernelci.org/content/en/docs/legacy/instances/chromeos/chromeos_changelog.md
@@ -33,15 +33,15 @@ Specific instructions on how to fetch and build ChromiumOS from a manifest file 
 Direct links for each supported board in this release are provided below for convenience.
 | Board       | Kernels shipped in image | Kernels tested by KernelCI (replacing image kernels during boot) |
 |-------------|:------------:|:-------:|
-| [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20231106.0/arm64) | v6.4.x<br> + display patches<br> + panfrost | stable:linux-6.1.y |
+| [asurada](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-asurada/20231106.0/arm64) | v6.6.x<br> + panfrost | stable:linux-6.1.y |
 | [brya](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-brya/20231106.0/amd64) | default | stable:linux-6.1.y |
-| [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64) | linux-next 20230203<br> + mtk HW enablement patches<br> + panfrost | |
+| [cherry](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-cherry/20231106.0/arm64) | v6.6.x<br> + 3 display patches<br> + panfrost | |
 | [coral](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-coral/20231106.0/amd64) | default | stable:linux-6.1.y |
 | [dedede](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-dedede/20231106.0/amd64/) | default | stable:linux-6.1.y |
 | [grunt](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-grunt/20231106.0/amd64/) | default | stable:linux-6.1.y |
 | [guybrush](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-guybrush/20231106.0/amd64/) | default | stable:linux-6.1.y |
 | [hatch](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-hatch/20231106.0/amd64/) | default | stable:linux-6.1.y |
-| [jacuzzi](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20231106.0/arm64/) | v6.4.x <br> + panfrost | stable:linux-6.1.y <br> next-integration-branch (for-kernelci) |
+| [jacuzzi](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-jacuzzi/20231106.0/arm64/) | v6.6.x + panfrost | stable:linux-6.1.y <br> next-integration-branch (for-kernelci) |
 | [nami](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-nami/20231106.0/amd64/) | default | stable:linux-6.1.y |
 | [octopus](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-octopus/20231106.0/amd64/) | chromeos-5.15 | stable:linux-6.1.y |
 | [puff](https://storage.chromeos.kernelci.org/images/rootfs/chromeos/chromiumos-puff/20231106.0/amd64/) | default | stable:linux-6.1.y |
@@ -63,9 +63,11 @@ Direct links for each supported board in this release are provided below for con
 - Fixed broken portage manifest for media-libs/cros-camera-libfs
 - Masked newer chromeos-chrome ebuild version which doesn't have a binpkg, to avoid unnecessarily long build times.
 - Bumped chromeos-installer ebuild as a result of forking the platform2 overlay.
+- Bumped MTK kernel used for jacuzzi, asurada and cherry to 6.6.
 
 #### platform2:
 - Forked to disable failing installer tpm check, until a fix is  landed for b:291036452.
+- Backported [a fix](https://chromium-review.googlesource.com/c/chromiumos/platform2/+/4894393) for secagentd builds against kernel 6.6.
 
 #### graphics:
 - Backported patch from R119 to avoid a conflict, still need to keep this patch in R118
@@ -73,9 +75,13 @@ Direct links for each supported board in this release are provided below for con
 #### board-overlays:
 - Forward ported the last remaining commit without conflicts. Will keep it for now but gradually will reduce its footprint as MTK SoCs start using the newer Google kernels with 6.6
 - Bumped octopus to 5.15 because tast fails with 4.14.
+- Cherry is now using the 6.6.x stable upstream kernel branch instead of the older 6.2 -next based branch.
 
 #### third_party/kernel/v5.10:
 - Removed fork in favor of chromeos-kernel-5_10
+
+#### third_party/kernel/upstream:
+- Bumped to 6.6.x plus 3 remaining display patches for cherry.
 
 ## R116
 


### PR DESCRIPTION
This PR contains 2 commits and needs to wait until @nuclearcat fixes the 6.6 Tast tests and also the following kernelci-core PR lands:

 https://github.com/kernelci/kernelci-core/pull/2208