### PR TITLE
Web Dashboard WG: Remove inactive member

### DIFF
--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -23,7 +23,6 @@ as:
 **Team:**
 
 * [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan` - Lead
-* [Alexandra Pereira](mailto:<alexandra.pereira@collabora.com>) - `apereira`
 * [Greg Kroah-Hartman](mailto:<gregkh@linuxfoundation.org>) - `gregkh`
 * [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
 * [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) - `glunardi`


### PR DESCRIPTION
Alex has left Collabora a while ago and never participated in the project again, so we are removing her.

For future removals, we probably want to push a vote through the WG.