### PR TITLE
Web Dashboard WG: Document mailing list

### DIFF
--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -20,6 +20,8 @@ as:
 
 **Workboard:** https://github.com/orgs/kernelci/projects/4
 
+**Mailing list:** [kernelci-webdashboard@groups.io](mailto:<kernelci-webdashboard@groups.io>)
+
 **Team:**
 
 * [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan` - Lead


### PR DESCRIPTION
Add info about the mailing list we just created for the Web Dashboard Working Group.