### PR TITLE
README.md: fix static website sample commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ To set up a local development server with Docker:
 
 ```sh
 $ git clone https://github.com/kernelci/kernelci-project.git
-$ cd kernelci.org
+$ cd kernelci-project
 $ sudo apt install -y git-lfs
 $ git-lfs fetch
 $ git-lfs checkout
 $ git submodule update --init --recursive
+$ cd kernelci.org
 ```
 
 Then to start the server:


### PR DESCRIPTION
Tweak the sample commands for setting up a local static website instance.  The git-lfs and submodule commands should be run the top-level directory while the Hugo server needs to be run from within the kernelci.org sub-directory.

Fixes: 4706e7272f79 ("README.md: add section about the kernelci.org static website")