### PR TITLE
kernelci.org: add blog about UX Analysis project

### DIFF
--- a/kernelci.org/content/en/blog/posts/2023/ux-analysis/index.md
+++ b/kernelci.org/content/en/blog/posts/2023/ux-analysis/index.md
@@ -1,0 +1,42 @@
+---
+date: 2023-12-04
+title: "UX Analysis"
+linkTitle: "UX Analysis"
+author: Guillaume Tucker
+description: >
+  KernelCI User Experience Analysis
+---
+
+Following the [UX Analysis RFP](/blog/posts/2023/rfp-ux-analysis/) we shared a
+few months ago, we're now delighted to announce that the KernelCI Advisory
+Board has accepted a proposal.  First of all, we're grateful to have received
+such a series of high-quality proposals.  Many thanks once again to all the
+submitters for your interest in the project.
+
+After carefully considering all the options with the board and some TSC
+members, the vote came out in favour of
+[ProFUSION](https://profusion.mobi/index-en.html).  Congratulations!  We're
+looking forward to the next milestones, in fact the work has already started.
+
+## Milestones
+
+The UX Analysis project is broken down into three milestones with four weeks
+assigned to each, so a total of twelve weeks.  Some breaks will also be
+scheduled during this time so the calendar end date is likely to be in March
+2024.
+
+### M1: Result of interviews
+
+Some interviews will be carried out with various stakeholders to help refine
+user stories and start modelling the user experience and some design aspects.
+
+### M2: First UX design proposal
+
+A first interactive prototype will then be created and made available for
+members of the public to evaluate and provide feedback.
+
+### M3: Final UX design proposal
+
+Based on the feedback and outcome of the first two milestones, the last part is
+about creating high-level specifications of the web dashboard design suitable
+for the implementation phase.


### PR DESCRIPTION
Add a blog post about the UX Analysis project starting now with ProFUSION following the RFP published earlier in 2023.