### PR TITLE
github: assign Early Access issues to nuclearcat

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-early-access.md
+++ b/.github/ISSUE_TEMPLATE/api-early-access.md
@@ -4,7 +4,7 @@ about: Request to get an early-access account for the new API
 title: Request API account for USER
 labels: ''
 assignees:
-  - gctucker
+  - nuclearcat
   - JenySadadia
 ---
 


### PR DESCRIPTION
Replace gctucker with nuclearcat as the default assignees in the template for Early Access account creation issues.