### PR TITLE
kernelci.org: add link to TSC meeting details

### DIFF
--- a/kernelci.org/content/en/docs/org/tsc/_index.md
+++ b/kernelci.org/content/en/docs/org/tsc/_index.md
@@ -36,7 +36,8 @@ list can be used.  To contact only the TSC members directly, the
 used instead.
 
 The TSC also meet monthly online to discuss current topics and make decisions
-including votes when necessary.
+including votes when necessary.  See the [Meetings
+section](/docs/org/#technical-steering-committee) for more details.
 
 ## Rules
 


### PR DESCRIPTION
Add a link on the TSC page to the Meetings section with the details about the TSC monthlies.