### PR TITLE
kernelci.org: add Advisory Board role definitions

### DIFF
--- a/kernelci.org/content/en/docs/org/board.md
+++ b/kernelci.org/content/en/docs/org/board.md
@@ -1,7 +1,7 @@
 ---
 title: "Advisory Board"
-date: 2021-09-03
-description: "Representatives from each member organization"
+date: 2023-12-12
+description: "Linux Foundation Project Board"
 weight: 2
 aliases:
   - "/docs/team/board"
@@ -11,11 +11,13 @@ The Advisory Board (AB) is composed of one representative from each premium
 member organization, one representative for every five general member
 organizations (maximum of three) and the TSC Chair.
 
-The board elects one Chair and one Treasurer each year. A budget is agreed each
-year and voted by the board.
+By the end of December each year, the Board agrees on a budget for the next
+year and submits it to the Linux Foundation.  It then elects a Chair, a
+Treasurer and a General Members representative for the following year.  The new
+roles and budget take effect on January 1st.
 
-There is also a Project Manager role to help coordinating things with the wider
-team.
+In addition to the elected roles, there is also an appointed Project Manager to
+help coordinate activities with the TSC, working groups and the wider team.
 
 As of today, the Advisory Board is composed of the members listed below with
 their respective roles, email address and IRC nicknames:
@@ -31,6 +33,74 @@ their respective roles, email address and IRC nicknames:
 * [KY Srinivasan](mailto:<kys@microsoft.com>) (Microsoft)
 * [Veronika Kabatov](mailto:<vkabatov@redhat.com>) (Redhat) - `vkabatova`
 
-
 Learn more about the [current members](/docs/org/members) or how to join on the
 [KernelCI Linux Foundation](https://foundation.kernelci.org/) website.
+
+## Key Roles
+
+As a matter of transparency and to ensure long-term continuity of operation,
+some key roles for the Board are defined below.  These are based on the Funding
+Charter as well as various contracts and other agreements to reflect the status
+quo.
+
+### Chair
+
+As per the Funding Charter provided by the Linux Foundation:
+
+> The Chair will preside over meetings of the Governing Board, manage any
+> day-to-day operational decisions, and will submit minutes for Governing Board
+> approval.
+
+Then in the particular case of KernelCI, past discussions have led the Board to
+agree on the following responsibilities:
+
+* Plan and execute on the project's initiatives autonomously
+* Drive the AB and TSC to help reach the strategic priorities of the project
+* Encourage strong engagement and community participation
+* Explore relationships with industry alliances to increase the project's reach
+* Participate in the community to help foster adoption and collaboration
+* Develop partnerships and other strategic relationships with key projects and
+  companies
+* Promote the project for potential new members to join
+* Devise and deliver visibility for the project at key conferences and events
+* Attend conferences and organize speaking engagements at relevant events
+
+### Treasurer
+
+As per the Funding Charter provided by the Linux Foundation:
+
+> The Treasurer will assist in the preparation of budgets for Governing Board
+> approval, monitor expenses against the budget and authorize expenditures
+> approved in the budget.
+
+The specifics for KernelCI are not further detailed but typically include
+liaising with the Linux Foundation for any finance-related business such as
+setting up contracts and dealing with invoices.
+
+### Project Manager
+
+While many projects have a PM, this particular role has been entirely defined
+by KernelCI board members with the following responsibilities:
+
+* Manage the day-to-day activities for the project (both AB and TSC efforts)
+* Organize and run the AB regular calls and meetings
+* Mediate potential conflicts that may arise in the AB and TSC
+* Report the progress of the project to the LF Technical Advisory Board (TAB)
+* Ensure the maintenance of the project infrastructure is happening (build
+  farms, test labs, test nodes, key databases etc.)
+* Prioritize work that drives toward completion of the project objectives and
+  key results (OKRs)
+* Coordinate note taking and the capture of action items
+* Communicate progress and status via reports
+* Ensure action items are managed and delivered
+
+### Representatives
+
+Other voting members of the Board include:
+
+* Premium Member representatives
+* General Member representatives
+* TSC representative
+
+They are all expected to cast a vote and take part in the Board meetings to
+take initiatives and help the project thrive.


### PR DESCRIPTION
Add a section on the Advisory Board page with definitions for the key roles (Chair, Treasurer, PM).  Also update the wording in the intro paragraph accordingly.