### PR TITLE
kernelci.org: update board members list

### DIFF
--- a/kernelci.org/content/en/docs/org/board.md
+++ b/kernelci.org/content/en/docs/org/board.md
@@ -19,19 +19,18 @@ roles and budget take effect on January 1st.
 In addition to the elected roles, there is also an appointed Project Manager to
 help coordinate activities with the TSC, working groups and the wider team.
 
-As of today, the Advisory Board is composed of the members listed below with
+As of 2024, the Advisory Board is composed of the members listed below with
 their respective roles, email address and IRC nicknames:
 
-* [Chris Paterson](mailto:<chris.paterson2@renesas.com>) (CIP, Treasurer) - `patersonc`
-* [Don Zickus](mailto:<dzickus@redhat.com>) (Redhat)
+* [Chris Paterson](mailto:<chris.paterson2@renesas.com>) (Civil Infrastructure Platform project, Treasurer) - `patersonc`
+* [Don Zickus](mailto:<dzickus@redhat.com>) (Red Hat, Chair)
 * [Greg Kroah-Hartman](mailto:<gregkh@linuxfoundation.org>) (Linux Foundation) - `gregkh`
 * [Guenter Roeck](mailto:<groeck@google.com>) (Google)
-* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) (Collabora, Chair and Acting TSC Chair) - `gtucker`
+* [Guillaume Tucker](mailto:<gtucker@gtucker.io>) (TSC Chair) - `gtucker`
 * [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) (Collabora, Project Manager) - `padovan`
 * [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) (Collabora, Marketing) - `glunardi`
 * [Kevin Hilman](mailto:<khilman@baylibre.com>) (BayLibre, General Members Representative) - `khilman`
 * [KY Srinivasan](mailto:<kys@microsoft.com>) (Microsoft)
-* [Veronika Kabatov](mailto:<vkabatov@redhat.com>) (Redhat) - `vkabatova`
 
 Learn more about the [current members](/docs/org/members) or how to join on the
 [KernelCI Linux Foundation](https://foundation.kernelci.org/) website.


### PR DESCRIPTION
Update the list of board members now that elections have taken place. The main change is that Don has been elected AB Chair for 2024.