### PR TITLE
kernelci.org: add Jeny to the list of TSC members

### DIFF
--- a/kernelci.org/content/en/docs/org/tsc/_index.md
+++ b/kernelci.org/content/en/docs/org/tsc/_index.md
@@ -26,6 +26,7 @@ respective email address and IRC nicknames:
 * [Michał Gałka](mailto:<galka.michal@gmail.com>) - `mgalka`
 * [Alice Ferrazzi](mailto:<alice.ferrazzi@miraclelinux.com>) - `alicef`
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat`
+* [Jeny Sadadia](mailto:jeny.sadadia@collabora.com) - `Jeny`
 
 ## Communication
 


### PR DESCRIPTION
As per the TSC vote last week, add Jeny to the list of TSC members.