### PR TITLE
kernelci.org: update gtucker's email address

### DIFF
--- a/kernelci.org/content/en/docs/org/tsc/_index.md
+++ b/kernelci.org/content/en/docs/org/tsc/_index.md
@@ -21,7 +21,7 @@ respective email address and IRC nicknames:
 
 * [Kevin Hilman](mailto:<khilman@baylibre.com>) - `khilman`
 * [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`
-* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
+* [Guillaume Tucker](mailto:<gtucker@gtucker.io>) - `gtucker`
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`
 * [Michał Gałka](mailto:<galka.michal@gmail.com>) - `mgalka`
 * [Alice Ferrazzi](mailto:<alice.ferrazzi@miraclelinux.com>) - `alicef`

--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -50,7 +50,7 @@ potentially a new design from scratch using modern web technology.
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat` - Lead
 * [Michał Gałka](mailto:<galka.michal@gmail.com>) - `mgalka`
 * [Corentin Labbe](mailto:<clabbe@baylibre.com>) - `montjoie`
-* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
+* [Guillaume Tucker](mailto:<gtucker@gtucker.io>) - `gtucker`
 * [Kevin Hilman](mailto:<khilman@baylibre.com>) - `khilman`
 * [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`


### PR DESCRIPTION
Replace guillaume.tucker@collabora.com with gtucker.io in the list of members of the TSC and the SySadmin working group.