### PR TITLE
kernelci.org: remove gtucker from Web Dashboard working group

### DIFF
--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -26,7 +26,6 @@ as:
 
 * [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan` - Lead
 * [Greg Kroah-Hartman](mailto:<gregkh@linuxfoundation.org>) - `gregkh`
-* [Guillaume Tucker](mailto:<guillaume.tucker@collabora.com>) - `gtucker`
 * [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) - `glunardi`
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`
 


### PR DESCRIPTION
As the RFP phase is now complete and I'm no longer going to be directly involved in the Web Dashboard activities, remove gtucker from the working group as discussed with Gustavo and others.