### PR TITLE
kernelci.org: add padovan to groups.io maintainers

### DIFF
--- a/kernelci.org/content/en/docs/org/maintainers.md
+++ b/kernelci.org/content/en/docs/org/maintainers.md
@@ -233,7 +233,7 @@ Maintaining them includes moderating incoming messages and new subscriptions,
 keeping settings up-to-date and dealing with changes to the schemes for each
 price plan.
 
-* Maintainers: `broonie`, `khilman`
+* Maintainers: `broonie`, `khilman`, `padovan`
 
 ### Slack
 


### PR DESCRIPTION
Add Gustavo Padovan to the list of groups.io maintainers.  There hasn't been any TSC vote as this is not a change of role but only a documentation update to align it with the current state of things.