### PR TITLE
kernelci.org: add cros-ec-tests component to Native Tests

### DIFF
--- a/kernelci.org/content/en/docs/org/maintainers.md
+++ b/kernelci.org/content/en/docs/org/maintainers.md
@@ -178,6 +178,7 @@ results into the database.
 * Components:
   [`test-definitions`](https://github.com/kernelci/test-definitions),
   [`bootrr`](https://github.com/kernelci/bootrr),
+  [`cros-ec-tests`](https://github.com/kernelci/cros-ec-tests),
   [`buildroot`](https://github.com/kernelci/buildroot),
   [`kernelci-core/config`](https://github.com/kernelci/kernelci-core/tree/main/config)
 * Services: Jenkins


### PR DESCRIPTION
Add the cros-ec-tests repository to the list of components for the Native Tests feature on the Maintainers page.