### PR TITLE
Update legacy How-To with Debian Bullseye

### DIFF
--- a/kernelci.org/content/en/docs/legacy/how-to.md
+++ b/kernelci.org/content/en/docs/legacy/how-to.md
@@ -157,11 +157,8 @@ required at this point.
 
 These changes are enough to make an intial pull request in
 [`kernelci-core`](https://github.com/kernelci/kernelci-core), and the test will
-automatically get run on [staging](../../instances/staging).  Then the results
-will appear on the web dashboard, for example:
-
-[Results for uname: «staging-next-20210805.0» on «minnowboard-max-E3825»
-(kernelci / staging-next)](https://staging.kernelci.org/test/plan/id/610ba7049064c472532a361e/)
+automatically get run on [staging](/docs/legacy/instances/staging/).  Then the
+results will appear on the [web dashboard](https://staging.kernelci.org/job/).
 
 > **Note** First-time contributors needed to be added to the [list of trusted
 GitHub
@@ -226,9 +223,7 @@ as a test case:
 
 We now have 2 test cases, one with the shell version and one with the C
 version.  After updating the pull request on GitHub, this will also get tested
-automatically on staging.  Here's some sample results:
-
-[Results for uname: «staging-mainline-20210805.0» on «minnowboard-max-E3825» (kernelci / staging-mainline)](https://staging.kernelci.org/test/plan/id/610bc171b2d76ba86d2a361e/)
+automatically on staging.
 
 > **Note** If one of the steps fails, the job will abort.  So if `apt install`
 or `wget` fails, the tests won't be run and the LAVA job status will show an

--- a/kernelci.org/content/en/docs/legacy/how-to.md
+++ b/kernelci.org/content/en/docs/legacy/how-to.md
@@ -1,6 +1,6 @@
 ---
 title: "How-To"
-date: 2023-08-11
+date: 2024-01-18
 description: "How to add a new native test suite"
 ---
 
@@ -20,8 +20,8 @@ every revision covered by KernelCI.  All the tests are part of fixed root file
 systems (rootfs), which get updated typically once a week.  Adding a test
 therefore involves either reusing an existing rootfs or creating a new one.
 
-A good way to start prototyping things is to use the plain [Debian Buster NFS
-rootfs](https://storage.kernelci.org/images/rootfs/debian/buster/) and install
+A good way to start prototyping things is to use the plain [Debian Bullseye NFS
+rootfs](https://storage.kernelci.org/images/rootfs/debian/bullseye/) and install
 or compile anything at runtime on the target platform itself.  This is of
 course slower and less reliable than using a tailored rootfs with everything
 already set up, but it allows a lot more flexibility.  It is the approach
@@ -126,14 +126,14 @@ enable uname test plan using Buster NFS`
 Once the LAVA templates have been created, the next step is to enable the test
 plan in the [KernelCI YAML configuration](../../core/config).
 
-First add the `uname` test plan with the chosen rootfs (Debian Buster NFS in
+First add the `uname` test plan with the chosen rootfs (Debian Bullseye NFS in
 this case) in `test-configs.yaml`:
 
 ```yaml
 test_plans:
 
   uname:
-    rootfs: debian_buster_nfs
+    rootfs: debian_bullseye_nfs
 ```
 
 Then define which platforms should run this test plan, still in
@@ -273,13 +273,13 @@ file with some parameters.  There are also extra dedicated files in
 [`config/rootfs`](https://github.com/kernelci/kernelci-core/tree/main/config/rootfs/)
 such as additional build scripts.
 
-Let's take a look at the `buster-v4l2` rootfs for example:
+Let's take a look at the `bullseye-v4l2` rootfs for example:
 
 ```yaml
 rootfs_configs:
-  buster-v4l2:
+  bullseye-v4l2:
     rootfs_type: debos
-    debian_release: buster
+    debian_release: bullseye
     arch_list:
       - amd64
       - arm64
@@ -293,7 +293,14 @@ rootfs_configs:
       - bash
       - e2fslibs
       - e2fsprogs
-    script: "scripts/buster-v4l2.sh"
+    extra_firmware:
+        - mediatek/mt8173/vpu_d.bin
+        - mediatek/mt8173/vpu_p.bin
+        - mediatek/mt8183/scp.img
+        - mediatek/mt8186/scp.img
+        - mediatek/mt8192/scp.img
+        - mediatek/mt8195/scp.img
+    script: "scripts/bullseye-v4l2.sh"
     test_overlay: "overlays/v4l2"
 ```
 
@@ -301,6 +308,8 @@ rootfs_configs:
 * `extra_packages` is a list passed to the package manager to install them.
 * `extra_packages_remove` is a list passed to the package manager to remove
   them.
+* `extra_firmware` is a list of Linux kernel firmware blobs to be installed in
+  the rootfs image.
 * `script` is an arbitrary script to be run after packages have been installed.
   In this case, it will build and install the `v4l2` tools to be able to run
   `v4l2-compliance`.
@@ -317,7 +326,7 @@ rootfs_configs:
           └── v4l2-parser.sh
   ```
 
-Here's a sample command using `kci_rootfs` to build the `buster-v4l2` root file
+Here's a sample command using `kci_rootfs` to build the `bullseye-v4l2` root file
 system for `amd64`:
 
 ```
@@ -328,8 +337,8 @@ $ docker run -it \
   kernelci/debos
 root@759fc147da29:/# cd /tmp/kernelci-core
 root@759fc147da29:~/kernelci-core# ./kci_rootfs build \
-  --rootfs-config=buster-v4l2 \
-   --arch=amd64
+  --rootfs-config=bullseye-v4l2 \
+  --arch=amd64
 ```
 
 ### Writing more advanced test definitions

--- a/kernelci.org/content/en/docs/legacy/how-to.md
+++ b/kernelci.org/content/en/docs/legacy/how-to.md
@@ -56,7 +56,7 @@ $ echo $?
 All the steps required to enable this test to run in KernelCI are detailed
 below.  There is also a sample Git branch with the changes:
 
-  https://github.com/kernelci/kernelci-core/commits/how-to
+  https://github.com/kernelci/kernelci-core/commits/how-to-bullseye
 
 ## Step 1: Enable basic test plan
 
@@ -65,9 +65,8 @@ mentioned above.
 
 ### LAVA job template
 
-See commit on the [how-to
-branch](https://github.com/kernelci/kernelci-core/commits/how-to): `config/lava:
-add uname test plan for the How-To guide`
+See commit: [`config/lava: add uname test plan for the How-To
+guide`](https://github.com/kernelci/kernelci-core/commit/b1464ff3986ac70513c251f3f1d87f892c556d61)
 
 KernelCI LAVA templates use [Jinja](https://jinja.palletsprojects.com/).  To
 add this `uname` test plan, create a template file
@@ -119,9 +118,8 @@ and the rootfs available over `nfs`.
 
 ### KernelCI YAML configuration
 
-See commit on the [how-to
-branch](https://github.com/kernelci/kernelci-core/commits/how-to): `config/core:
-enable uname test plan using Buster NFS`
+See commit: [`config/core: enable uname test plan using Bullseye
+NFS`](https://github.com/kernelci/kernelci-core/commit/e7c1a1a0277fec215b778da3ada8885581464a16)
 
 Once the LAVA templates have been created, the next step is to enable the test
 plan in the [KernelCI YAML configuration](../../core/config).
@@ -172,18 +170,17 @@ by a maintainer before their pull requests get merged and deployed on staging.
 
 ## Step 2: Modify the file system at runtime
 
-Most tests will require more than what is already available in a plain Buster
+Most tests will require more than what is already available in a plain Bullseye
 rootfs.  Let's see how this can be done in a simple way.
 
 ### Add a C file: uname-os.c
 
-See commit on the [how-to
-branch](https://github.com/kernelci/kernelci-core/commits/how-to):
-`config/lava: add uname-os.c`
+See commit: [`config/lava: add
+uname-os.c`](https://github.com/kernelci/kernelci-core/commit/d31ee9462c0edf680509431f01d7ffce0ef23074)
 
 For example, we could have the test implemented as a C program rather than a
 shell script.  See the
-[`uname-os.c`](https://github.com/kernelci/kernelci-core/blob/how-to/config/lava/uname/uname-os.c)
+[`uname-os.c`](https://github.com/kernelci/kernelci-core/blob/how-to-bullseye/config/lava/uname/uname-os.c)
 file.
 
 To test it locally:
@@ -209,9 +206,8 @@ Now, let's see how this can be used with KernelCI.
 
 ### Build it and run the C implementation
 
-See commit on the [how-to
-branch](https://github.com/kernelci/kernelci-core/commits/how-to):
-`config/lava: download and build uname-os.c and use it`
+See commit: [`config/lava: download and build uname-os.c and use
+it`](https://github.com/kernelci/kernelci-core/commit/66eb1aab440157747d458e088610a1764b983441)
 
 Any arbitrary commands can be added to the `uname.jinja2` template before
 running the actual test cases.  In this example, we can install Debian packages
@@ -222,7 +218,7 @@ as a test case:
           steps:
           - apt update
           - apt install -y wget gcc
-          - wget https://raw.githubusercontent.com/kernelci/kernelci-core/how-to/config/lava/uname/uname-os.c
+          - wget https://raw.githubusercontent.com/kernelci/kernelci-core/how-to-bullseye/config/lava/uname/uname-os.c
           - gcc -o uname-os uname-os.c
           - lava-test-case uname-os-shell --shell '[ $(uname -o) = "GNU/Linux" ]'
           - lava-test-case uname-os-c --shell './uname-os'

--- a/kernelci.org/content/en/docs/legacy/how-to.md
+++ b/kernelci.org/content/en/docs/legacy/how-to.md
@@ -122,7 +122,7 @@ See commit: [`config/core: enable uname test plan using Bullseye
 NFS`](https://github.com/kernelci/kernelci-core/commit/e7c1a1a0277fec215b778da3ada8885581464a16)
 
 Once the LAVA templates have been created, the next step is to enable the test
-plan in the [KernelCI YAML configuration](../../core/config).
+plan in the [KernelCI YAML configuration](/docs/legacy/core/config/).
 
 First add the `uname` test plan with the chosen rootfs (Debian Bullseye NFS in
 this case) in `test-configs.yaml`:
@@ -257,8 +257,9 @@ a more advanced feature for grouping test results together inside a test suite.
 
 ### Adding a rootfs variant
 
-Root file systems are built using the [`kci_rootfs`](../../core/kci_rootfs)
-command.  All the variants are defined in the
+Root file systems are built using the
+[`kci_rootfs`](/docs/legacy/core/kci_rootfs) command.  All the variants are
+defined in the
 [`config/core/rootfs-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/main/config/core/rootfs-configs.yaml)
 file with some parameters.  There are also extra dedicated files in
 [`config/rootfs`](https://github.com/kernelci/kernelci-core/tree/main/config/rootfs/)


### PR DESCRIPTION
Update the legacy How-To documentation page about how to add new LAVA tests using Debian Bullseye.  Also fix some loose ends and dead links.

Fixes #307