### PR TITLE
kernelci.org: remove gtucker from SysAdmin working group

### DIFF
--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -1,6 +1,6 @@
 ---
 title: "Working groups"
-date: 2022-03-15
+date: 2023-02-19
 description: "KernelCI Working Groups"
 weight: 4
 ---
@@ -49,7 +49,6 @@ potentially a new design from scratch using modern web technology.
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat` - Lead
 * [Michał Gałka](mailto:<galka.michal@gmail.com>) - `mgalka`
 * [Corentin Labbe](mailto:<clabbe@baylibre.com>) - `montjoie`
-* [Guillaume Tucker](mailto:<gtucker@gtucker.io>) - `gtucker`
 * [Kevin Hilman](mailto:<khilman@baylibre.com>) - `khilman`
 * [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`


### PR DESCRIPTION
Remove gtucker from the list of SysAdmin working group members. Related permissions and admin rights are in the process of being disabled or revoked accordingly.