### PR TITLE
github: add issue template for new TSC members

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-tsc-member.md
+++ b/.github/ISSUE_TEMPLATE/new-tsc-member.md
@@ -1,0 +1,16 @@
+---
+name: New TSC member
+about: Checklist to add a new TSC member
+title: "Add TSC member: FULL NAME"
+assignees: 'padovan'
+---
+
+Please go through all the checklist below to add @_USERNAME_ (_FULL NAME_) as a member of the [TSC](https://kernelci.org/docs/org/tsc/):
+
+- [ ] [TSC voting record](https://kernelci.org/docs/org/tsc/votes/) added to the documentation
+- [ ] [TSC members](https://kernelci.org/docs/org/tsc/#members) documentation updated with new member's name, email and IRC nickname
+- [ ] New member invited to join [`kernelci-tsc@groups.io`](https://groups.io/g/kernelci-tsc)
+- [ ] New member invited to the [monthly TSC meeting](https://kernelci.org/docs/org/#technical-steering-committee)
+- [ ] TSC documents shared with the new member (meeting minutes in Google Docs etc.)
+- [ ] New member invited to any relevant [Slack](https://kernelci.slack.com) private channels (if applicable)
+- [ ] Induction about [TSC rules and duties](https://kernelci.org/docs/org/tsc/#rules) with Chair or other committee members completed


### PR DESCRIPTION
Add a GitHub issue template to create a checklist used when adding a new member to Technical Steering Committee (TSC).