### PR TITLE
kernelci.org: update favicon with white background

### DIFF
--- a/kernelci.org/static/favicons/android-144x144.png
+++ b/kernelci.org/static/favicons/android-144x144.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:acd272a286e8110676b57adb692f88bb938fd6723b5b68f5977dc65600704d7d
-size 8798
+oid sha256:f2724f766ff364a55a0c0b3c2b1c66f43265650d54e8659ee064c14c023f49a8
+size 13990

--- a/kernelci.org/static/favicons/android-192x192.png
+++ b/kernelci.org/static/favicons/android-192x192.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0bb649f0e989c9b5d6a5875e03dc801d83fc1977573cbd4a21fc9ab6c7b083db
-size 11875
+oid sha256:fade7cef00c2015b661107bcd2cb2f8b120fa12d8185e8ef18dedd0a1ad7e3a4
+size 17482

--- a/kernelci.org/static/favicons/android-36x36.png
+++ b/kernelci.org/static/favicons/android-36x36.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:913635600a148820a69583bdd2616cbb7325ca01ca48d12d691b40dfe51eb26a
-size 1972
+oid sha256:08c8dc128995f9a216f32098eae50030c421bc8d37f9fad49925f9dc44cab386
+size 6240

--- a/kernelci.org/static/favicons/android-48x48.png
+++ b/kernelci.org/static/favicons/android-48x48.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a32762709895ceda5e4a3951a2168bcbf8a88ecf324a3164f733d4241f761aae
-size 2703
+oid sha256:73b4b43cc834820ee1e9fe27a29905489dc9ef43849cf55670057fa1ab8c87fd
+size 7144

--- a/kernelci.org/static/favicons/android-72x72.png
+++ b/kernelci.org/static/favicons/android-72x72.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a773d301f0b941423e94d04599e54e8f8dbf7697bbc0e3f5cbea2e5626ad90fb
-size 4214
+oid sha256:3ef1da7b9ca48c3bfaf7e252f83ded42942189524f1c6a7883489e1c9286523e
+size 8859

--- a/kernelci.org/static/favicons/android-96x96.png
+++ b/kernelci.org/static/favicons/android-96x96.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a398e52b54378fc749deb632c43809e570f8a1332f7b9d17235950aa2ad8346e
-size 5701
+oid sha256:e181d1d74be2701f6a5b297ae8c6261de8113599488358c6d13febdd4972e28c
+size 10529

--- a/kernelci.org/static/favicons/favicon-1024.png
+++ b/kernelci.org/static/favicons/favicon-1024.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98df76054ce4ba4fb7c647b7f6056c066b0e24cf8b7ef96564d5a2c80e1e4da7
-size 74148
+oid sha256:2d14c9346d8f434daa25ab1cde54c146d8e5e1aeec44cb1ba45b3ca5c949cc6b
+size 86525

--- a/kernelci.org/static/favicons/favicon-16x16.png
+++ b/kernelci.org/static/favicons/favicon-16x16.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15e6e53e96501b2272500a731d809e438da55bd9f1bb0798b05c3f8a9798a873
-size 761
+oid sha256:ba7db081f5847a341a4940ac2c9d763e8a5e151a7ed956dea61a4424de746809
+size 4899

--- a/kernelci.org/static/favicons/favicon-256.png
+++ b/kernelci.org/static/favicons/favicon-256.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dbe05a94adfe55d3ee413b3a21a7fee17f0684d440c1dda0634bbfdd51e7edc
-size 16174
+oid sha256:b9e41f47feb6208788186112e737379ee5520f01078dae458663371c79fb4392
+size 22343

--- a/kernelci.org/static/favicons/favicon-32x32.png
+++ b/kernelci.org/static/favicons/favicon-32x32.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dd3d71fc9dcdcf4015baffde0cb8dd0855876f32ba739aaa6b07732bdf52fc74
-size 1744
+oid sha256:9c048f8b433f87b7c436452b9529260a7e7afca65f54ac89c96d9c0da995e2dc
+size 5899

--- a/kernelci.org/static/favicons/favicon.ico
+++ b/kernelci.org/static/favicons/favicon.ico
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1dbe05a94adfe55d3ee413b3a21a7fee17f0684d440c1dda0634bbfdd51e7edc
-size 16174
+oid sha256:b9e41f47feb6208788186112e737379ee5520f01078dae458663371c79fb4392
+size 22343


### PR DESCRIPTION
The KernelCI logo was designed to be with a white background but the PNG favicon files have a transparent background.  This poses some problems with dark themes as it make it hardly visible.

Update all the favicon PNG files with opaque white background.