### PR TITLE
kernelci.org: replace stale kernelci@groups.io links in blog

### DIFF
--- a/kernelci.org/content/en/blog/posts/2020/05/11/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/05/11/index.html
@@ -90,7 +90,7 @@ public (details below.)</p>
   <li>LinkedIn:
     <a href="https://www.linkedin.com/company/kernelci-org/">https://www.linkedin.com/company/kernelci-org/ </a></li>
   <li>Mailing list for technical discussions and weekly updates:
-    <a href="https://groups.io/g/kernelci/topics">https://groups.io/g/kernelci/topics</a></li>
+    <a href="https://lore.kernel.org/kernelci/">https://lore.kernel.org/kernelci/</a></li>
 </ul>
 <p>Engage</p>
 <ul>

--- a/kernelci.org/content/en/blog/posts/2020/11/05/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/11/05/index.html
@@ -50,7 +50,7 @@ tailor-made, which doesn’t scale very well and is very hard to maintain.</p>
 features to be able to do that. As a first step, we are collecting user stories.
 If you have any, such as “I want to find out all the test results for the
 devices in my lab”, feel free to reply to this thread:
-<br><a href="https://groups.io/g/kernelci/topic/rfc_dashboards/77367531">https://groups.io/g/kernelci/topic/rfc_dashboards/77367531<br></a>
+<br><a href="https://lore.kernel.org/all/7hk0w2c4i3.fsf@baylibre.com/">https://lore.kernel.org/all/7hk0w2c4i3.fsf@baylibre.com/<br></a>
 "RFC: dashboards, visualization and analytics for test results"</p>
 
 

--- a/kernelci.org/content/en/blog/posts/2021/03/16/index.html
+++ b/kernelci.org/content/en/blog/posts/2021/03/16/index.html
@@ -97,4 +97,4 @@ in a few areas to help guide the future of the project.</p>
 <p>Please keep in touch with what we’re up to or to get involved, you can read
 <a href="https://foundation.kernelci.org/blog/">our blog</a>, follow on twitter
 <a href="https://twitter.com/kernelci">@kernelci</a> or join our
-<a href="https://groups.io/g/kernelci/topics">mailing list</a>.</p>
+<a href="https://lore.kernel.org/kernelci/">mailing list</a>.</p>

--- a/kernelci.org/content/en/blog/posts/2021/hackfests/index.md
+++ b/kernelci.org/content/en/blog/posts/2021/hackfests/index.md
@@ -19,7 +19,7 @@ flavours, bringing up new types of hardware to be tested...
 
 There have been two hackfests to date. The current plan is to hold one
 every few months.  Future hackfests will be announced on the [KernelCI mailing
-list](https://groups.io/g/kernelci/topics) as well as [LKML](https://lkml.org/)
+list](https://lore.kernel.org/kernelci/) as well as [LKML](https://lkml.org/)
 and [Twitter](https://twitter.com/kernelci).  Stay tuned!
 
 


### PR DESCRIPTION
Update all the stale links to the kernelci@groups.io archive in all the blog posts with corresponding ones to the new archive on lore.kernel.org.