### PR TITLE
kernelci.org: fix working groups page date

### DIFF
--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -1,6 +1,6 @@
 ---
 title: "Working groups"
-date: 2023-02-19
+date: 2024-02-19
 description: "KernelCI Working Groups"
 weight: 4
 ---


### PR DESCRIPTION
Fix the date set on the working groups page (2024 instead of 2023, that was a typo).

Fixes: 00a84b06b2da ("kernelci.org: remove gtucker from SysAdmin working group")