### PR TITLE
tsc: update IRC nickname for Jeny

### DIFF
--- a/kernelci.org/content/en/docs/org/tsc/_index.md
+++ b/kernelci.org/content/en/docs/org/tsc/_index.md
@@ -26,7 +26,7 @@ respective email address and IRC nicknames:
 * [Michał Gałka](mailto:<galka.michal@gmail.com>) - `mgalka`
 * [Alice Ferrazzi](mailto:<alice.ferrazzi@miraclelinux.com>) - `alicef`
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat`
-* [Jeny Sadadia](mailto:jeny.sadadia@collabora.com) - `Jeny`
+* [Jeny Sadadia](mailto:jeny.sadadia@collabora.com) - `jenysadadia`
 * [Paweł Wieczorek](mailto:pawiecz@collabora.com) - `pawiecz`
 
 ## Communication


### PR DESCRIPTION
As I have updated my IRC nickname to `jenysadadia`, reflect the change in the TSC members' list.