### PR TITLE
kernelci.org: add spbnick as TSC Chair to board members

### DIFF
--- a/kernelci.org/content/en/docs/org/board.md
+++ b/kernelci.org/content/en/docs/org/board.md
@@ -1,6 +1,6 @@
 ---
 title: "Advisory Board"
-date: 2024-02-19
+date: 2024-04-01
 description: "Linux Foundation Project Board"
 weight: 2
 aliases:
@@ -30,6 +30,7 @@ their respective roles, email address and IRC nicknames:
 * [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) (Collabora, Marketing) - `glunardi`
 * [Kevin Hilman](mailto:<khilman@baylibre.com>) (BayLibre, General Members Representative) - `khilman`
 * [KY Srinivasan](mailto:<kys@microsoft.com>) (Microsoft)
+* [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) (TSC Chair) - `spbnick`
 
 Learn more about the [current members](/docs/org/members) or how to join on the
 [KernelCI Linux Foundation](https://foundation.kernelci.org/) website.


### PR DESCRIPTION
Add Nikolai Kondrashov (spbnick) to the list of voting board members as the new TSC Chair.  This is effective on 2024-04-01 as per the TSC vote on 2024-03-14.