### PR TITLE
kernelci.org: add -F option in docker-compose

### DIFF
--- a/kernelci.org/docker-compose.yaml
+++ b/kernelci.org/docker-compose.yaml
@@ -16,3 +16,4 @@ services:
     command:
       - 'server'
       - '-D'
+      - '-F'


### PR DESCRIPTION
Add the Hugo -F option in docker-compose.yaml to also render pages with a publication date set in the future.

This is useful as the docker-compose setup uses the Hugo development server for previewing changes, not generating the static files served in a production deployment where only pages with a publication date in the past should be rendered.