### PR TITLE
kernelci.org: update members of the Web Dashboard WG

### DIFF
--- a/kernelci.org/content/en/docs/org/working-groups.md
+++ b/kernelci.org/content/en/docs/org/working-groups.md
@@ -26,7 +26,7 @@ as:
 
 * [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan` - Lead
 * [Greg Kroah-Hartman](mailto:<gregkh@linuxfoundation.org>) - `gregkh`
-* [Guy Lunardi](mailto:<guy.lunardi@collabora.com>) - `glunardi`
+* [Ricardo Cañuelo](mailto:<ricardo.canuelo@collabora.com>) - `hardboprobot`
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) - `spbnick`
 
 As KernelCI keeps growing, and based on the results of the [2020 Community


### PR DESCRIPTION
Add Ricardo, who has been participating in the discussions and remove Guy, who hasn't been active.