### PR TITLE
workflows/deploy: Strip 2 directories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,3 +50,4 @@ jobs:
           port: ${{ secrets.WEB_STAGING_PORT }}
           source: "kernelci.org/public/"
           target: ${{ secrets.WEB_STAGING_DIR }}
+          strip-components: 2


### PR DESCRIPTION
For correct deployment we need to strip 2 elements from path.