### PR TITLE
kernelci.org: update gtucker maintainer roles

### DIFF
--- a/kernelci.org/content/en/docs/org/maintainers.md
+++ b/kernelci.org/content/en/docs/org/maintainers.md
@@ -40,7 +40,7 @@ removing projects, configurating workboards and updating any other general
 settings.
 
 * Organisation: https://github.com/kernelci
-* Owners: `broonie`, `khilman`, `gtucker`, `nuclearcat`
+* Owners: `broonie`, `khilman`, `nuclearcat`
 
 ### Project
 
@@ -242,7 +242,7 @@ The [KernelCI Slack channel](https://kernelci.slack.com) may be used as an
 alternative to IRC.  However, more people are using IRC so Slack is only there
 to facilitate communication when IRC is not practical.
 
-* Maintainers: `khilman`, `spbnick`, `gtucker`
+* Maintainers: `khilman`, `spbnick`
 
 ### Twitter
 


### PR DESCRIPTION
Remove gtucker from the list of maintainers for the GitHub kernelci org and Slack as per the TSC vote on 2024-05-13.