### PR TITLE
kernelci.org: make link to Foundation more meaningful

### DIFF
--- a/kernelci.org/config.toml
+++ b/kernelci.org/config.toml
@@ -83,7 +83,7 @@ footer_about_disable = false
 
   [[menu.main]]
     identifier = "lf"
-    name = "LF"
+    name = "Foundation"
     url = "https://foundation.kernelci.org"
 
   [[menu.main]]


### PR DESCRIPTION
Let's just call it Foundation as "LF" fails to share enough context to the average visitor.