### PR TITLE
docs: updates links after DNS switch

### DIFF
--- a/kernelci.org/config.toml
+++ b/kernelci.org/config.toml
@@ -77,6 +77,12 @@ footer_about_disable = false
 
 [menu]
   [[menu.main]]
+    identifier = "foundation"
+    name = "Home"
+    url = "https://kernelci.org"
+    weight = 1
+
+  [[menu.main]]
     identifier = "documentation"
     name = "Documentation"
     url = "/"
@@ -86,11 +92,6 @@ footer_about_disable = false
     url = "https://linux.kernelci.org/job"
 
   [[menu.main]]
-    identifier = "lf"
-    name = "Foundation"
-    url = "https://foundation.kernelci.org"
-
-  [[menu.main]]
     identifier = "blog"
     name = "Blog"
-    url = "https://foundation.kernelci.org/blog/"
+    url = "https://kernelci.org/blog/"

--- a/kernelci.org/content/en/_index.md
+++ b/kernelci.org/content/en/_index.md
@@ -37,4 +37,4 @@ their own tests can submit results to
 [BigQuery](https://cloud.google.com/bigquery) database to provide a unified
 kernel test reporting mechanism.  Please take a look at this blog post for a
 comprehensive description: [Introducing Common
-Reporting](https://foundation.kernelci.org/blog/2020/08/21/introducing-common-reporting/).
+Reporting](https://kernelci.org/blog/2020/08/21/introducing-common-reporting/).

--- a/kernelci.org/content/en/blog/posts/2020/05/11/index.html
+++ b/kernelci.org/content/en/blog/posts/2020/05/11/index.html
@@ -26,7 +26,7 @@ priorities for the technical steering committee.</p>
 <p>Recent GB accomplishments</p>
 <ul>
   <li>established and published project
-    <a href="https://foundation.kernelci.org/mission-objectives/">Mission &amp; Objectives</a></li>
+    <a href="https://kernelci.org/mission-objectives/">Mission &amp; Objectives</a></li>
   <li>welcomed <a href="https://ltsi.linuxfoundation.org/">Long-Term Stable Initiative (LTSi)</a>
     as associate member</li>
   <li>established collaborative development between existing CI projects under
@@ -84,7 +84,7 @@ public (details below.)</p>
   other ways to be involved in the discussion.</p>
 <p>Follow:</p>
 <ul>
-  <li>This blog: <a href="https://foundation.kernelci.org/blog/">https://foundation.kernelci.org/blog/</a></li>
+  <li>This blog: <a href="https://kernelci.org/blog/">https://kernelci.org/blog/</a></li>
   <li>Twitter: @kernelci, #kernelci -
     <a href="https://twitter.com/kernelci">https://twitter.com/kernelci </a></li>
   <li>LinkedIn:

--- a/kernelci.org/content/en/blog/posts/2021/03/16/index.html
+++ b/kernelci.org/content/en/blog/posts/2021/03/16/index.html
@@ -16,10 +16,10 @@ of KernelCI project, and highlight our goals for the next year.</p>
 <h2>Highlights of the first year</h2>
 <p>The founding members spent the end of 2019 doing a formal launch and ramping
 up the project structure and organization. This led to
-<a href="https://foundation.kernelci.org/mission-objectives/">our mission statement and key goals</a>.
+<a href="https://kernelci.org/mission-objectives/">our mission statement and key goals</a>.
 Throughout 2020 we gave talks and led discussions at several virtual conferences
 such as FOSDEM, Open-Source Summit / Embedded Linux Conference (ELC). Check out
-<a href="https://foundation.kernelci.org/blog/">our blog</a> for more details
+<a href="https://kernelci.org/blog/">our blog</a> for more details
 about the talks and discussions from these events.</p>
 
 <p><strong>Community Collaboration</strong></p>
@@ -27,12 +27,12 @@ about the talks and discussions from these events.</p>
 kernel testing and automation community was looking for. This survey has helped
 guide where we focus our time and resources. See our blog for an article
 covering the
-<a href="https://foundation.kernelci.org/blog/2020/07/09/kernelci-community-survey-report/">full results of the survey</a>.</p>
+<a href="https://kernelci.org/blog/2020/07/09/kernelci-community-survey-report/">full results of the survey</a>.</p>
 
 <p>One highlight of the 2020 conference circuit was Linux Plumbers Conference
 (LPC). At LPC, we gave talks and held focused discussions with our target
 audience: kernel developers and maintainers. The full details are
-<a href="https://foundation.kernelci.org/blog/2020/09/23/kernelci-notes-from-plumbers-2020/">in a blog article covering the event</a>,
+<a href="https://kernelci.org/blog/2020/09/23/kernelci-notes-from-plumbers-2020/">in a blog article covering the event</a>,
 but this is where we kicked off public discussions of how to unify test results
 and reporting from various testing and CI efforts in the community. We’re
 calling this common datastore for kernel testing results kcidb. Thanks to the
@@ -95,6 +95,6 @@ ideas and plans, but we’re still a very small team and are looking for experti
 in a few areas to help guide the future of the project.</p>
 
 <p>Please keep in touch with what we’re up to or to get involved, you can read
-<a href="https://foundation.kernelci.org/blog/">our blog</a>, follow on twitter
+<a href="https://kernelci.org/blog/">our blog</a>, follow on twitter
 <a href="https://twitter.com/kernelci">@kernelci</a> or join our
 <a href="https://lore.kernel.org/kernelci/">mailing list</a>.</p>

--- a/kernelci.org/content/en/blog/posts/2021/06/24/index.html
+++ b/kernelci.org/content/en/blog/posts/2021/06/24/index.html
@@ -80,4 +80,4 @@ raise your hand and join the next time a KernelCI hackfest happens.</p>
 
 <p>KernelCI is a Linux Foundation project. If you are interested in learning
 more or becoming a member
-<a href="https://foundation.kernelci.org/#message">contact us</a>.</p>
+<a href="https://kernelci.org/#message">contact us</a>.</p>

--- a/kernelci.org/content/en/org/board.md
+++ b/kernelci.org/content/en/org/board.md
@@ -33,7 +33,7 @@ their respective roles, email address and IRC nicknames:
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) (TSC Chair) - `spbnick`
 
 Learn more about the [current members](/docs/org/members) or how to join on the
-[KernelCI Linux Foundation](https://foundation.kernelci.org/) website.
+[KernelCI Linux Foundation](https://kernelci.org/) website.
 
 ## Key Roles
 


### PR DESCRIPTION
Our foundation website is became our main kernelci.org website. So we can point there as 'Home´ and also drop the "foundation.' part of the urls.