### PR TITLE
New landing page for Documentation

### DIFF
--- a/kernelci.org/content/en/_index.md
+++ b/kernelci.org/content/en/_index.md
@@ -11,30 +11,36 @@ cascade:
     path: "/**"
 ---
 
-Welcome to the KernelCI documentation website.  You'll find below a summary of
-the overall architecture and pointers to the main sections.
+Welcome to the KernelCI documentation website.
 
-## Overall Architecture
 
-![architecture](/image/kernelci-architecture.png)
+<div class="container border border-primary rounded p-2">
+  <h2 class="text-center">
+    <a href="kernel-community">Kernel Community</a>
+  </h2>
+  <p class="text-center">Start here if you are Kernel developer/maintainer
+  and want to add your tree and tests.</p>
+</div>
 
-The first thing worth noting here is that there are two main parts of the
-overall KernelCI architecture:
+<div class="container border border-primary rounded p-2 mt-3">
+  <h2 class="text-center">
+    <a href="labs">Labs</a>
+  </h2>
+  <p class="text-center">Start here if you want to add a lab to run KernelCI tests.</p>
+</div>
 
-### [API & Pipeline](api_pipeline)
+<div class="container border border-primary rounded p-2 mt-3">
+  <h2 class="text-center">
+    <a href="kcidb">KCIDB</a>
+  </h2>
+  <p class="text-center">Start here if you want
+  to contribute your results to the KernelCI common database. KCIDB can receive tests results from any CI system.</p>
+</div>
 
-The top half of this picture shows native services interacting directly with
-the API: LAVA test labs, Kubernetes clusters, custom test environments and the
-job scheduler.  These are referred to as the KernelCI Pipeline in a loose
-sense.  Such services can be run pretty much anywhere, they are just API
-clients with a particular purpose.
-
-### [KCIDB](kcidb)
-
-Other fully autonomous systems producing their own kernel builds and running
-their own tests can submit results to
-[KCIDB](kcidb), which is a
-[BigQuery](https://cloud.google.com/bigquery) database to provide a unified
-kernel test reporting mechanism.  Please take a look at this blog post for a
-comprehensive description: [Introducing Common
-Reporting](https://kernelci.org/blog/2020/08/21/introducing-common-reporting/).
+<div class="container border border-primary rounded p-2 mt-3">
+  <h2 class="text-center">
+    <a href="architecture">Contributing to KernelCI</a>
+  </h2>
+  <p class="text-center">Start here if you want to contribute to KernelCI and learn
+  more about our <a href="architecture">technical architecture</a>.</p>
+</div>

--- a/kernelci.org/content/en/architecture/_index.md
+++ b/kernelci.org/content/en/architecture/_index.md
@@ -1,0 +1,28 @@
+---
+title: "KernelCI Architecture"
+date: 2024-07-03
+description: "Learn the inner details behind the KernelCI systems"
+---
+
+![architecture](/image/kernelci-architecture.png)
+
+The first thing worth noting here is that there are two main parts of the
+overall KernelCI architecture:
+
+### [API & Pipeline](../api_pipeline)
+
+The top half of this picture shows native services interacting directly with
+the API: LAVA test labs, Kubernetes clusters, custom test environments and the
+job scheduler.  These are referred to as the KernelCI Pipeline in a loose
+sense.  Such services can be run pretty much anywhere, they are just API
+clients with a particular purpose.
+
+### [KCIDB](../kcidb)
+
+Other fully autonomous systems producing their own kernel builds and running
+their own tests can submit results to
+[KCIDB](../kcidb), which is a
+[BigQuery](https://cloud.google.com/bigquery) database to provide a unified
+kernel test reporting mechanism.  Please take a look at this blog post for a
+comprehensive description: [Introducing Common
+Reporting](https://kernelci.org/blog/2020/08/21/introducing-common-reporting/).

--- a/kernelci.org/content/en/kernel-community/_index.md
+++ b/kernelci.org/content/en/kernel-community/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Kernel Community"
+date: 2024-07-03
+description: "Adding trees, tests and interacting with tests results"
+weight: 2
+---
+
+The Kernel Community is the audience of KernelCI. Upstream maintainers and developers, product makers, hardware vendors, etc. are all interested in getting the kernel tested on a variety of scenarios.
+
+> This documentation is still a **WIP**. As we ready new KernelCI for more users the documentation is being improved and expanded.
+
+This section of the documentation shares instructions to:
+* [enable kernel testing for your tree/branch](../api_pipeline/pipeline/developer-documentation/#enabling-a-new-kernel-tree)
+* [enable specific tests](../api_pipeline/pipeline/developer-documentation/#enabling-a-new-test)
+* visualize the results(TBD)
+
+We know that the documentation above may not answer all your questions. We are working to improve it. We ask you to reach out to our mailing list at [kernelci@lists.linux.dev](mailto:kernelci@lists.linux.dev)  with questions and feedback. We are eager to hear from you!

--- a/kernelci.org/content/en/labs/_index.md
+++ b/kernelci.org/content/en/labs/_index.md
@@ -8,9 +8,11 @@ Anyone can connect their test labs to KernelCI. Once a lab is connected to Kerne
 
 It is up to each lab to define whether it will receive specific test configurations or a generic range of test jobs. If the lab is a LAVA lab, for example, the KernelCI [LAVA runtime](../api_pipeline/pipeline/connecting-lab) will generate test jobs for each single test that is configured to run. On the other hand, if a lab is implementing its own runtime (or bridge to Maestro APIs), they may choose to generate the individual test jobs themselves.
 
-If you are interested it just sending the results of test runs in your infrastructure, you should look at sending the data to [KCIDB](../kcidb) - KernelCI common database for results.
+If you are interested in just sending the results of test runs in your infrastructure, you should look at sending the data to [KCIDB](../kcidb) - KernelCI common database for results.
 
 There are a few ways labs can be connected to KernelCI. The documentation for connecting labs in the new architecture is evolving as we add labs.
 
 * [Connecting a LAVA lab](../api_pipeline/pipeline/connecting-lab)
-* Writing your own bride/runtime using Maestro APIs (TBD)
+* Writing your own bridge/runtime using Maestro APIs (doc TBD, see this [GitHub issue](https://github.com/kernelci/kernelci-project/issues/349#issuecomment-2097641023))
+
+We know that the documentation above may not answer all your questions. We are working to improve it. We ask you to reach out to our mailing list at [kernelci@lists.linux.dev](mailto:kernelci@lists.linux.dev)  with questions and feedback. We are eager to hear from you!


### PR DESCRIPTION
We have several types of audience; our documentation should reflect that. This PR is a initial step into creating a foundation to grow Documentation to our different types of users. You can see the proposed new users in the screenshot below.

![Screenshot from 2024-07-03 15-30-55](https://github.com/kernelci/kernelci-project/assets/40303/1c22bb48-5981-472d-a807-504b271fe7d6)

Once we merge this, we can iterative improve the documentation (as it is being discussed in different forums).

this include the patch from #405 too.
