### PR TITLE
docs: remove leftover background image

### DIFF
--- a/kernelci.org/content/en/background.jpeg
+++ b/kernelci.org/content/en/background.jpeg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c58f6285d9d67b892550ee6a12fe792f91777d8fba69b40fa2670bb024e12353
-size 1363809


### PR DESCRIPTION
We don't use it anymore in the new configuration.