### PR TITLE
docs: add link to documentation on visualize the results

### DIFF
--- a/kernelci.org/content/en/kernel-community/_index.md
+++ b/kernelci.org/content/en/kernel-community/_index.md
@@ -12,6 +12,6 @@ The Kernel Community is the audience of KernelCI. Upstream maintainers and devel
 This section of the documentation shares instructions to:
 * [enable kernel testing for your tree/branch](../maestro/pipeline/developer-documentation/#enabling-a-new-kernel-tree)
 * [enable specific tests](../maestro/pipeline/developer-documentation/#enabling-a-new-test)
-* visualize the results(TBD)
+* [visualize the results](https://grafana.kernelci.org/d/OKXc44EIz/home?orgId=1&viewPanel=49)
 
 We know that the documentation above may not answer all your questions. We are working to improve it. We ask you to reach out to our mailing list at [kernelci@lists.linux.dev](mailto:kernelci@lists.linux.dev)  with questions and feedback. We are eager to hear from you!


### PR DESCRIPTION
Add link to point to the documentation in the grafana dashboard.