### PR TITLE
docs: Fix lots of links

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-tsc-member.md
+++ b/.github/ISSUE_TEMPLATE/new-tsc-member.md
@@ -5,12 +5,12 @@ title: "Add TSC member: FULL NAME"
 assignees: 'padovan'
 ---
 
-Please go through all the checklist below to add @_USERNAME_ (_FULL NAME_) as a member of the [TSC](https://kernelci.org/docs/org/tsc/):
+Please go through all the checklist below to add @_USERNAME_ (_FULL NAME_) as a member of the [TSC](https://docs.kernelci.org/org/tsc/):
 
-- [ ] [TSC voting record](https://kernelci.org/docs/org/tsc/votes/) added to the documentation
-- [ ] [TSC members](https://kernelci.org/docs/org/tsc/#members) documentation updated with new member's name, email and IRC nickname
+- [ ] [TSC voting record](https://docs.kernelci.org/org/tsc/votes/) added to the documentation
+- [ ] [TSC members](https://docs.kernelci.org/org/tsc/#members) documentation updated with new member's name, email and IRC nickname
 - [ ] New member invited to join [`kernelci-tsc@groups.io`](https://groups.io/g/kernelci-tsc)
-- [ ] New member invited to the [monthly TSC meeting](https://kernelci.org/docs/org/#technical-steering-committee)
+- [ ] New member invited to the [monthly TSC meeting](https://docs.kernelci.org/org/#technical-steering-committee)
 - [ ] TSC documents shared with the new member (meeting minutes in Google Docs etc.)
 - [ ] New member invited to any relevant [Slack](https://kernelci.slack.com) private channels (if applicable)
-- [ ] Induction about [TSC rules and duties](https://kernelci.org/docs/org/tsc/#rules) with Chair or other committee members completed
+- [ ] Induction about [TSC rules and duties](https://docs.kernelci.org/org/tsc/#rules) with Chair or other committee members completed

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Secrets and git-crypt
 
 The [`secrets`](https://github.com/kernelci/kernelci-project/tree/main/secrets)
 directory contains encrypted files with credentials used by the KernelCI
-project.  See the [Secrets](https://kernelci.org/docs/admin/secrets/) page for
+project.  See the [Secrets](https://docs.kernelci.org/admin/secrets/) page for
 more details about how it is used.

--- a/kernelci.org/content/en/admin/api.md
+++ b/kernelci.org/content/en/admin/api.md
@@ -39,7 +39,7 @@ by mistake.
 ## Creating user accounts
 
 > **Note**: This is how things are done as part of the [Early
-> Access](/docs/api/early-access) phase.  The procedure once in production
+> Access](/api/early-access) phase.  The procedure once in production
 > might change if users can just sign up by themselves.
 
 First, create a random password and then use it with `kci user add` to create
@@ -94,7 +94,7 @@ and the associated share name is:
 Please take a look at the Early Access documentation page to update your API
 account with your own password and get started:
 
-  https://kernelci.org/docs/api/early-access/
+  https://docs.kernelci.org/api/early-access/
 
 Happy beta-testing!
 ```

--- a/kernelci.org/content/en/admin/secrets.md
+++ b/kernelci.org/content/en/admin/secrets.md
@@ -8,7 +8,7 @@ The [`secrets`](https://github.com/kernelci/kernelci-project/tree/main/secrets)
 directory contains encrypted files using
 [`git-crypt`](https://www.agwa.name/projects/git-crypt/) with credentials used
 by the KernelCI project.  It is mostly useful to project administrators such as
-members of the [TSC](/docs/org/tsc), for example to have a common place where
+members of the [TSC](/org/tsc), for example to have a common place where
 to share passwords in a secure way.  Derivative projects based on KernelCI such
 as private instances may reuse some of the tools and documentation provided
 here.

--- a/kernelci.org/content/en/blog/posts/2021/hackfests/index.md
+++ b/kernelci.org/content/en/blog/posts/2021/hackfests/index.md
@@ -43,7 +43,7 @@ test, say in kselftest.  A second participant enables the test to run in
 KernelCI, which fails in some cases and a kernel bug is found.  A third
 participant makes a fix for the bug, which can then be tested directly in
 KernelCI to confirm it works as expected.  This may even happen on the [staging
-instance](/docs/instances/staging/) before the patches for the test and the fix
+instance](/instances/staging/) before the patches for the test and the fix
 are sent to any mailing list, in which case the fix would get a `Tested-by:
 "kernelci.org bot" <bot@kernelci.org>` trailer from the start.  This scenario
 also relies on some hardware previously made available in test labs by other
@@ -75,7 +75,7 @@ Here's a summary of the first two hackfests:
 
 * Workboard: https://github.com/orgs/kernelci/projects/5
 * Participants
-  * More members of the [TSC](/docs/org/tsc/) took part than first hackfest
+  * More members of the [TSC](/org/tsc/) took part than first hackfest
   * New contributor: Denis Efremov (floppy disk kernel maintainer)
   * Arisu from [Civil Infrastructure Platform](https://www.cip-project.org/)
     (CIP) / [Cybertrust Japan](https://www.cybertrust.co.jp/english/)

--- a/kernelci.org/content/en/blog/posts/2022/sysadmin-onboard/index.md
+++ b/kernelci.org/content/en/blog/posts/2022/sysadmin-onboard/index.md
@@ -14,12 +14,12 @@ that the KernelCI advisory board hired Vince Hillier from Revenni Inc to
 conduct the work.
 
 Vince will work together with the Technical Steering Committee
-([TSC](/docs/org/tsc/)) to maintain and improve the current project
+([TSC](/org/tsc/)) to maintain and improve the current project
 infrastructure. As KernelCI.org scales with more kernels being built and more
 tests being run, we definitely need help to keep our systems stable and up to
 date.
 
 The KernelCI project relies on a number of web services which need constant
 maintenance. These include databases, automation tools and web dashboards for
-several [instances](/docs/instances/). Some are hosted on dedicated virtual
+several [instances](/instances/). Some are hosted on dedicated virtual
 machines (VMs), others in the cloud.

--- a/kernelci.org/content/en/blog/posts/2023/api-early-access/index.md
+++ b/kernelci.org/content/en/blog/posts/2023/api-early-access/index.md
@@ -14,7 +14,7 @@ explained briefly in the [previous blog
 post](https://kernelci.org/blog/posts/2023/api-timeline/), this is to give
 everyone a chance to create a user account and start using the API for
 beta-testing purposes.  There's now an [Early
-Access](https://kernelci.org/docs/api/early-access/) documentation page with a
+Access](https://docs.kernelci.org/api/early-access/) documentation page with a
 quick guide to get started, so please go take a look there and start taking
 part.
 

--- a/kernelci.org/content/en/blog/posts/2023/api-timeline/index.md
+++ b/kernelci.org/content/en/blog/posts/2023/api-timeline/index.md
@@ -126,7 +126,7 @@ legacy system _no sooner than_ announced here.
 In the meantime, we'll be posting updates as these milestones get reached or if
 any alterations need to be managed.  We'll also clarify how to use the API and
 exactly what features become available alongside the main
-[documentation](/docs/api).  Please share with us any feedback you may have, if
+[documentation](/api).  Please share with us any feedback you may have, if
 you need some clarifications or to raise any concerns.  The best way to do this
 is via the [mailing list](mailto:kernelci@lists.linux.dev) as always.  Stay
 tuned!

--- a/kernelci.org/content/en/blog/posts/2023/fosdem-2023/index.md
+++ b/kernelci.org/content/en/blog/posts/2023/fosdem-2023/index.md
@@ -19,10 +19,10 @@ Remind yourself and your interlocutors of the importance of testing and the exis
 
 ## Find out more about KernelCI	
 
-Mission statement: https://kernelci.org/docs/org/
+Mission statement: https://kernelci.org/org/
 
 Interested to see your tests ran by KernelCI natively?
-Here is how to [get started](https://kernelci.org/docs/tests/howto/) with KernelCI.
+Here is how to [get started](https://docs.kernelci.org/tests/howto/) with KernelCI.
 
 You already have your own automated execution of tests and would be interested/willing to contribute your results? Please see the [KCIDB submitter guide](https://github.com/kernelci/kcidb/blob/main/doc/submitter_guide.md).
 

--- a/kernelci.org/content/en/blog/posts/2023/rfp-ux-analysis-q-and-a/index.md
+++ b/kernelci.org/content/en/blog/posts/2023/rfp-ux-analysis-q-and-a/index.md
@@ -148,7 +148,7 @@ objects.  The underlying engine is MongoDB, and we're looking into using Atlas
 for this.  The API also features a Pub/Sub interface for events that trigger
 different stages of the testing pipeline on the client side.
 
-The [KCIDB](https://kernelci.org/docs/kcidb/) database has a different schema,
+The [KCIDB](https://docs.kernelci.org/kcidb/) database has a different schema,
 but the web dashboard wouldn't necessarily need to read data from both sources.
 That's something we still need to define, there are several ways to solve this.
 It's also something which might depend on the outcome of the UX Analysis.

--- a/kernelci.org/content/en/blog/posts/2024/strategic-updates/index.md
+++ b/kernelci.org/content/en/blog/posts/2024/strategic-updates/index.md
@@ -46,4 +46,4 @@ As you can see, a lot is going on in KernelCI at the moment. The team is iterati
 
 That's all for now! Stay tuned for updates on topics discussed in this article. Likewise, as the new infrastructure stabilizes, expect a significant amount of documentation updates too.
 
-We thank all KernelCI [member organizations](https://kernelci.org/docs/org/members/) and developer community who have been investing in the project over the years. It is only because of the continued support from our community that we are making the legacy system a past story!
+We thank all KernelCI [member organizations](https://docs.kernelci.org/org/members/) and developer community who have been investing in the project over the years. It is only because of the continued support from our community that we are making the legacy system a past story!

--- a/kernelci.org/content/en/blog/posts/2024/tsc-updates/index.md
+++ b/kernelci.org/content/en/blog/posts/2024/tsc-updates/index.md
@@ -20,4 +20,4 @@ Nikolai has been a longstanding contributor under the KernelCI umbrella and the 
 While at it, we thank Guillaume for his tenure as TSC Chair of the project!
 
 The detail of the motions which were voted can be found on the TSC
-[documentation](https://kernelci.org/docs/org/tsc/votes/#2024-03-14).
+[documentation](https://docs.kernelci.org/org/tsc/votes/#2024-03-14).

--- a/kernelci.org/content/en/faq.md
+++ b/kernelci.org/content/en/faq.md
@@ -44,7 +44,7 @@ used.
 them with KernelCI?**
 
 A section of the documentation is dedicated to [adding new test
-suites](/docs/tests/howto/).
+suites](/tests/howto/).
 
 Each test is a bit different as they all have their own dependencies and are
 written in various languages. Typically, they will require a user-space image

--- a/kernelci.org/content/en/legacy/_index.md
+++ b/kernelci.org/content/en/legacy/_index.md
@@ -34,7 +34,7 @@ KernelCI native tests are orchestrated using the following components:
   connected to KernelCI services to run tests and send results directly to the
   backend.
 
-There are several [instances](/docs/legacy/instances) hosted by the KernelCI
+There are several [instances](/legacy/instances) hosted by the KernelCI
 project, for different needs as explained in the documentation.  Each instance
 is made up of all the components listed above.  It's possible for anyone to set
 up their own private instance too.  However, developers typically don't need to

--- a/kernelci.org/content/en/legacy/contrib.md
+++ b/kernelci.org/content/en/legacy/contrib.md
@@ -9,11 +9,11 @@ KernelCI core project is open for contributions. Contributions may consist of
 adding new builds, tests and device types as well as features and bugfixes for
 KernelCI core tools.
 The best way to contribute is to send a PR to [kernelci-core](https://github.com/kernelci/kernelci-core).
-When the PR is created, the [KernelCI staging](https://kernelci.org/docs/instances/staging)
+When the PR is created, the [KernelCI staging](https://docs.kernelci.org/instances/staging)
 instance takes care of updating the [staging.kernelci.org branch](https://github.com/kernelci/kernelci-core/tree/staging.kernelci.org).
 In general the branch is updated every 8h and a limited set of builds and tests
 are run on it. More detailed information about the logic behind staging runs can
-be found [here](https://kernelci.org/docs/instances/staging).
+be found [here](https://docs.kernelci.org/instances/staging).
 
 There are several guidelines which can facilitate the PR review process:
 
@@ -31,4 +31,4 @@ There are several guidelines which can facilitate the PR review process:
    1. When there are comments unanswered for more than 1 month the PR will be closed
 4. In case there is a need to consult the PR with KernelCI maintainers join the open hours
    1. Open hours take place every Thursday at 12:00 UTC at KernelCI [Jitsi](https://meet.kernel.social/kernelci-dev)
-5. Should you need help, you can reach KernelCI [maintainers](/docs/org/maintainers/)
+5. Should you need help, you can reach KernelCI [maintainers](/org/maintainers/)

--- a/kernelci.org/content/en/legacy/how-to.md
+++ b/kernelci.org/content/en/legacy/how-to.md
@@ -122,7 +122,7 @@ See commit: [`config/core: enable uname test plan using Bullseye
 NFS`](https://github.com/kernelci/kernelci-core/commit/e7c1a1a0277fec215b778da3ada8885581464a16)
 
 Once the LAVA templates have been created, the next step is to enable the test
-plan in the [KernelCI YAML configuration](/docs/legacy/core/config/).
+plan in the [KernelCI YAML configuration](/legacy/core/config/).
 
 First add the `uname` test plan with the chosen rootfs (Debian Bullseye NFS in
 this case) in `test-configs.yaml`:
@@ -157,7 +157,7 @@ required at this point.
 
 These changes are enough to make an intial pull request in
 [`kernelci-core`](https://github.com/kernelci/kernelci-core), and the test will
-automatically get run on [staging](/docs/legacy/instances/staging/).  Then the
+automatically get run on [staging](/legacy/instances/staging/).  Then the
 results will appear on the [web dashboard](https://staging.kernelci.org/job/).
 
 > **Note** First-time contributors needed to be added to the [list of trusted
@@ -258,7 +258,7 @@ a more advanced feature for grouping test results together inside a test suite.
 ### Adding a rootfs variant
 
 Root file systems are built using the
-[`kci_rootfs`](/docs/legacy/core/kci_rootfs) command.  All the variants are
+[`kci_rootfs`](/legacy/core/kci_rootfs) command.  All the variants are
 defined in the
 [`config/core/rootfs-configs.yaml`](https://github.com/kernelci/kernelci-core/blob/main/config/core/rootfs-configs.yaml)
 file with some parameters.  There are also extra dedicated files in

--- a/kernelci.org/content/en/legacy/instances/cip.md
+++ b/kernelci.org/content/en/legacy/instances/cip.md
@@ -9,12 +9,12 @@ The [Civil Infrastructure Platform](https://www.cip-project.org/) project (CIP)
 manages a separate instance of KernelCI. In reality this "instance" is part of
 the main [linux.kernelci.org](https://linux.kernelci.org) instance but the
 configuration of what is built and tested is managed in separate configuration
-files by [maintainers](https://kernelci.org/docs/org/tsc/#cip-instance) from the
+files by [maintainers](https://kernelci.org/org/tsc/#cip-instance) from the
 CIP project.
 
 The development and production workflows are identical to the main KernelCI
 instance. Visit the
-[production documentation](https://kernelci.org/docs/instances/production/) to
+[production documentation](https://docs.kernelci.org/instances/production/) to
 learn more about the process.
 
 The CIP "instance" can be accessed at the

--- a/kernelci.org/content/en/legacy/instances/local.md
+++ b/kernelci.org/content/en/legacy/instances/local.md
@@ -230,4 +230,4 @@ e.g.
 
 Congratulations, your `kernelci-backend` instance is up and running.
 You can now build your kernel and push the artifacts with `kci_build` and `kci_data`.
-See the [`kci_build`](https://kernelci.org/docs/core/kci_build/) documentation to get you started.
+See the [`kci_build`](https://docs.kernelci.org/core/kci_build/) documentation to get you started.

--- a/kernelci.org/content/en/legacy/maintainers.md
+++ b/kernelci.org/content/en/legacy/maintainers.md
@@ -63,7 +63,7 @@ gradually more continuous as services start to get hosted in the Cloud and run
 in Docker containers.
 
 * Dashboard: [linux.kernelci.org](https://linux.kernelci.org)
-* Description: [Production](/docs/instances/production)
+* Description: [Production](/instances/production)
 * Maintainers: `mgalka`, `nuclearcat`
 * Components: [`kernelci-deploy`](https://github.com/kernelci/kernelci-deploy)
 
@@ -72,10 +72,10 @@ in Docker containers.
 All the incoming pull requests are merged into temporary integration branches
 and deployed on [staging.kernelci.org](https://staging.kernelci.org] for
 testing.  This is explained in greater detail in the
-[Staging](/docs/instances/staging) section.
+[Staging](/instances/staging) section.
 
 * Dashboard: [staging.kernelci.org](https://staging.kernelci.org)
-* Description: [Staging](/docs/instances/staging)
+* Description: [Staging](/instances/staging)
 * Maintainers: `gtucker`, `broonie`, `nuclearcat`
 * Components: [`kernelci-deploy`](https://github.com/kernelci/kernelci-deploy)
 
@@ -89,7 +89,7 @@ rebased with any extra patches that are not merged upstream, typically after
 each production update.
 
 * Dashboard: [chromeos.kernelci.org](https://chromeos.kernelci.org)
-* Description: [ChromeOS](/docs/instances/chromeos)
+* Description: [ChromeOS](/instances/chromeos)
 * Maintainers: `mgalka`, `nuclearcat`
 * Components: [`kernelci-deploy`](https://github.com/kernelci/kernelci-deploy)
 
@@ -99,6 +99,6 @@ The CIP instance is dedicated to building CIP specific kernels with CIP
 configurations. Currently the CIP KernelCI code is in production.
 
 * Dashboard: [cip.kernelci.org](https://cip.kernelci.org)
-* Description: [CIP](/docs/instances/cip)
+* Description: [CIP](/instances/cip)
 * Maintainers: `arisut`
 * Components: [`kernelci-deploy`](https://github.com/kernelci/kernelci-deploy)

--- a/kernelci.org/content/en/maestro/_index.md
+++ b/kernelci.org/content/en/maestro/_index.md
@@ -91,7 +91,7 @@ GitHub merged together on a test integration branch.
 ### Early Access
 
 In preparation for a full production roll-out, an [Early
-Access](/docs/api_pipeline/api/early-access) instance has been deployed in the Cloud (AKS)
+Access](/api_pipeline/api/early-access) instance has been deployed in the Cloud (AKS)
 on `kernelci-api.westus3.cloudapp.azure.com`.  This is stable enough to let
 users give it a try as some form of beta-testing and is used as a candidate
 solution for an initial production deployment in the coming months.  Like

--- a/kernelci.org/content/en/org/_index.md
+++ b/kernelci.org/content/en/org/_index.md
@@ -4,7 +4,7 @@ date: 2021-09-03
 description: "KernelCI project organization"
 weight: 1
 aliases:
-  - "/docs/team/"
+  - "/team/"
 ---
 
 The KernelCI Linux Foundation project is composed of an [Advisory Board](board)
@@ -125,7 +125,7 @@ be shared during the Thursday meeting.
 
 * Every other Wednesday at 07:30 PST
 
-The [Advisory Board](/docs/org/board/) of members meet every other week to
+The [Advisory Board](/org/board/) of members meet every other week to
 discuss things that matter from the point of view of the KernelCI Linux
 Foundation project: budget, membership, work packages, internships etc.  It's a
 private meeting as only member representatives can attend.
@@ -134,7 +134,7 @@ private meeting as only member representatives can attend.
 
 * Every second Thursday of the month at 10:00 UTC
 
-The [Technical Steering Committee](/docs/org/tsc/) meet once a month to discuss
+The [Technical Steering Committee](/org/tsc/) meet once a month to discuss
 general technical topics that have a significant impact on the project.  This
 is a private meeting as only elected TSC members can attend and they
 occasionally take part in decisions made by the advisory board.

--- a/kernelci.org/content/en/org/board.md
+++ b/kernelci.org/content/en/org/board.md
@@ -4,7 +4,7 @@ date: 2024-04-01
 description: "Linux Foundation Project Board"
 weight: 2
 aliases:
-  - "/docs/team/board"
+  - "/team/board"
 ---
 
 The Advisory Board (AB) is composed of one representative from each premium
@@ -32,7 +32,7 @@ their respective roles, email address and IRC nicknames:
 * [KY Srinivasan](mailto:<kys@microsoft.com>) (Microsoft)
 * [Nikolai Kondrashov](mailto:<spbnick@gmail.com>) (TSC Chair) - `spbnick`
 
-Learn more about the [current members](/docs/org/members) or how to join on the
+Learn more about the [current members](/org/members) or how to join on the
 [KernelCI Linux Foundation](https://kernelci.org/) website.
 
 ## Key Roles

--- a/kernelci.org/content/en/org/maintainers.md
+++ b/kernelci.org/content/en/org/maintainers.md
@@ -22,7 +22,7 @@ There are several types of maintainer roles with different responsibilities:
 [channel maintainers](#channel-maintainers)
 : in charge of the communication channels used by KernelCI
 
-Most maintainers are members of the [TSC](/docs/org/tsc) but additional people
+Most maintainers are members of the [TSC](/org/tsc) but additional people
 can be involved too.
 
 ## Software Maintainers
@@ -58,7 +58,7 @@ information etc.).
 
 ### Core tools
 
-The [core tools](/docs/core) provide the command line utilities and the
+The [core tools](/core) provide the command line utilities and the
 `kernelci` Python package used to implement a KerneLCI pipeline and run
 individual steps by hand (building kernels, scheduling tests...).
 
@@ -68,7 +68,7 @@ individual steps by hand (building kernels, scheduling tests...).
 
 ### API
 
-The new [KernelCI API](/docs/api) is a work-in-progress replacement for the
+The new [KernelCI API](/api) is a work-in-progress replacement for the
 backend currently used in production.  It also features a Pub/Sub interface to
 coordinate the pipeline services in a modular fashion.
 
@@ -77,7 +77,7 @@ coordinate the pipeline services in a modular fashion.
 
 ### Pipeline
 
-The [KernelCI pipeline](/docs/api/overview/#pipeline-design) is also a
+The [KernelCI pipeline](/api/overview/#pipeline-design) is also a
 work-in-progress based on the new API and its Pub/Sub interface.  This is
 essentially to replace the Jenkins pipeline currently used in production.
 
@@ -87,7 +87,7 @@ essentially to replace the Jenkins pipeline currently used in production.
 
 ### KCIDB
 
-[KCIDB](/docs/kcidb) provides a set of tools to submit kernel test data to a
+[KCIDB](/kcidb) provides a set of tools to submit kernel test data to a
 common database.
 
 * Main repositories: [`kcidb`](https://github.com/kernelci/kcidb),
@@ -262,7 +262,7 @@ news and, achievements.
 ### kernelci.org update emails (paused)
 
 Emails are sent regularly with a summary of the changes going into production
-and minutes from the various [TSC](/docs/org/tsc) and
-[board](/docs/org/board) meetings.
+and minutes from the various [TSC](/org/tsc) and
+[board](/org/board) meetings.
 
 * Maintainers: `gtucker`

--- a/kernelci.org/content/en/org/tsc/_index.md
+++ b/kernelci.org/content/en/org/tsc/_index.md
@@ -4,7 +4,7 @@ date: 2024-03-18
 description: "KernelCI core developers and maintainers"
 weight: 3
 aliases:
-  - "/docs/team/tsc"
+  - "/team/tsc"
 ---
 
 The Technical Steering Committee (TSC) is a team of people who are responsible
@@ -40,7 +40,7 @@ used instead.
 
 The TSC also meet monthly online to discuss current topics and make decisions
 including votes when necessary.  See the [Meetings
-section](/docs/org/#technical-steering-committee) for more details.
+section](/org/#technical-steering-committee) for more details.
 
 ## Rules
 

--- a/kernelci.org/content/en/org/working-groups.md
+++ b/kernelci.org/content/en/org/working-groups.md
@@ -59,7 +59,7 @@ web servers, databases and Cloud services up and running.  This does not
 include any test lab other than some Kubernetes clusters as hardware platforms
 are maintained by separate companies and individuals.  Members of the SysAdmin
 working group have admin rights on all KernelCI systems, wherever applicable.
-As per the [2022-12-08 TSC vote](/docs/org/tsc/votes/#2022-12-08), admin rights
+As per the [2022-12-08 TSC vote](/org/tsc/votes/#2022-12-08), admin rights
 cover the following items:
 
 * Machines (SSH, sudo):


### PR DESCRIPTION
Since we moved the documentation domain to docs.kernelci.org we've left behind lots of broken links.

Hopefully this commit fixes them all!