### PR TITLE
Kernel Community doc: add link to KCIDB subscriber guide

### DIFF
--- a/kernelci.org/content/en/kernel-community/view-results.md
+++ b/kernelci.org/content/en/kernel-community/view-results.md
@@ -8,6 +8,6 @@ The Kernel Community has a few options to interact with the test results availab
 
 * [**Web Dashboard**](https://dashboard.kernelci.org/)(WIP): Our new Web Dashboard aims at providing an easy way for the community to look at the test results. It is still under development and we are open to your [feedback and feature requests](https://github.com/kernelci/dashboard).
 * [**Grafana**](https://grafana.kernelci.org/): Our Grafana instance allow users to create specific dashboard with tailored queries and boards. Those who want to dive deeper into their data can engage with our Grafana instance.
-* **Email reports**: [KCIDB](../../kcidb) allows users to create tailored email reports through [templates](https://github.com/kernelci/kcidb/tree/main/kcidb/templates). Email reports are sent to [kernelci-results@groups.io](https://groups.io/g/kernelci-results) and can also be sent to custom Cc email address.
+* **Email reports**: [KCIDB](../../kcidb) allows users to create tailored test reports and receive them via email notifications through [subscriptions](https://docs.kernelci.org/kcidb/subscriber_guide/). Email reports are sent to [kernelci-results@groups.io](https://groups.io/g/kernelci-results) and can also be sent to custom Cc email addresses.
 
 We know that the documentation above may not answer all your questions. We are working to improve it. We ask you to reach out to our mailing list at [kernelci@lists.linux.dev](mailto:kernelci@lists.linux.dev)  with questions and feedback. We are eager to hear from you!


### PR DESCRIPTION
In the `Evaluating Test Results` section, include link to KCIDB subscriber guide and remove KCIDB templates link. At the time of adding this doc, KCIDB subscriber guide didn't exist. Hence, update the links accordingly.