### PR TITLE
upd(website): Update Slack to Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-staging-access.md
+++ b/.github/ISSUE_TEMPLATE/api-staging-access.md
@@ -11,7 +11,7 @@ assignees:
 Maestro has a staging instance running for development purposes.
 It allows users to request an account on the new KernelCI API to give it a try. You can also enable your trees, builds, and tests on it. Here is the [developer documentation](https://docs.kernelci.org/maestro/pipeline/developer-documentation/) for the same.
 
-[Staging deployment](https://github.com/kernelci/kernelci-api/tree/main/kube/aks) can already run a pipeline with KUnit, kselftest, kernel builds and boot tests. So please give it a go and create issues on GitHub and ask  questions on the [mailing list](mailto:kernelci@lists.linux.dev), IRC `#kernelci` on libera.chat or [Slack](https://kernelci.slack.com) with whatever you may find.
+[Staging deployment](https://github.com/kernelci/kernelci-api/tree/main/kube/aks) can already run a pipeline with KUnit, kselftest, kernel builds and boot tests. So please give it a go and create issues on GitHub and ask  questions on the [mailing list](mailto:kernelci@lists.linux.dev), IRC `#kernelci` on libera.chat or [Discord](https://discord.gg/KWbrbWEyqb) with whatever you may find.
 
 Once the account request is accepted, a user account will be created by an admin and a random password will be sent to your email address.  You can then use `kci user password update` to set your own password, `kci user verify` to verify your email address, and `kci user token` to get an API token.  We'll also provide you with an AzureFiles share to use alongside the API, even though you may use any other storage as long as artifacts can be reached with a public HTTP URL.
 

--- a/.github/ISSUE_TEMPLATE/new-tsc-member.md
+++ b/.github/ISSUE_TEMPLATE/new-tsc-member.md
@@ -12,5 +12,5 @@ Please go through all the checklist below to add @_USERNAME_ (_FULL NAME_) as a 
 - [ ] New member invited to join [`kernelci-tsc@groups.io`](https://groups.io/g/kernelci-tsc)
 - [ ] New member invited to the [monthly TSC meeting](https://docs.kernelci.org/org/#technical-steering-committee)
 - [ ] TSC documents shared with the new member (meeting minutes in Google Docs etc.)
-- [ ] New member invited to any relevant [Slack](https://kernelci.slack.com) private channels (if applicable)
+- [ ] New member invited to any relevant private channels (if applicable)
 - [ ] Induction about [TSC rules and duties](https://docs.kernelci.org/org/tsc/#rules) with Chair or other committee members completed

--- a/kernelci.org/config.toml
+++ b/kernelci.org/config.toml
@@ -68,10 +68,10 @@ footer_about_disable = false
   desc = "Development takes place here!"
 
 [[params.links.developer]]
-  name = "Slack"
-  url = "http://kernelci.slack.com/"
-  icon = "fab fa-slack"
-  desc = "Chat with other project developers"
+  name = "Discord"
+  url = "https://discord.gg/KWbrbWEyqb"
+  icon = "fab fa-discord"
+  desc = "Chat with other developers!"
 
 # -- custom main menu --
 

--- a/kernelci.org/content/en/org/maintainers.md
+++ b/kernelci.org/content/en/org/maintainers.md
@@ -242,13 +242,13 @@ price plan.
 
 * Maintainers: `broonie`, `khilman`, `padovan`
 
-### Slack
+### Discord
 
-The [KernelCI Slack channel](https://kernelci.slack.com) may be used as an
-alternative to IRC.  However, more people are using IRC so Slack is only there
+The [KernelCI Discord channel](https://discord.gg/KWbrbWEyqb) may be used as an
+alternative to IRC.  However, more people are using IRC so Discord is only there
 to facilitate communication when IRC is not practical.
 
-* Maintainers: `khilman`, `spbnick`
+* Maintainers: `khilman`, `spbnick`, `padovan`
 
 ### Twitter
 


### PR DESCRIPTION
According to TSC voting we are migrating to Discord. All links and content need to be updated accordingly.