### PR TITLE
Rename `Early-access` with `Production`

### DIFF
--- a/kernelci.org/content/en/maestro/_index.md
+++ b/kernelci.org/content/en/maestro/_index.md
@@ -88,12 +88,9 @@ documentation](https://staging.kernelci.org:9000/latest/docs).  This instance
 is not stable, it's redeployed periodically with all open pull requests from
 GitHub merged together on a test integration branch.
 
-### Early Access
+### Production
 
-In preparation for a full production roll-out, an [Early
-Access](/api_pipeline/api/early-access) instance has been deployed in the Cloud (AKS)
-on `kernelci-api.westus3.cloudapp.azure.com`.  This is stable enough to let
-users give it a try as some form of beta-testing and is used as a candidate
-solution for an initial production deployment in the coming months.  Like
+Production instance has been deployed in the Cloud (AKS)
+on `kernelci-api.westus3.cloudapp.azure.com`. This is stable instance and is being updated weekly (usually on Mondays). Like
 staging, it has an auto-generated [interactive API
 documentation](https://kernelci-api.westus3.cloudapp.azure.com/latest/docs).


### PR DESCRIPTION
As we now have production instance deployed in place of early-access instance, update the documentation  accordingly.