### PR TITLE
upd(workflows/deploy.yml): Add comment in issue about staging website

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-22.04
     environment: stagingdeploy
+    permissions:
+      issues: write
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -90,6 +92,20 @@ jobs:
           remote_port: ${{ secrets.WEB_STAGING_PORT }}
           remote_user: ${{ secrets.WEB_STAGING_USERNAME }}
           remote_key: ${{ secrets.WEB_STAGING_KEY }}
+
+      - name: Leave comment in issue about staging URL
+        if: github.event.inputs.environment == 'staging' || github.event_name == 'issue_comment'
+        run: |
+          gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: >
+            Your PR has been deployed to staging.
+            Staging URL: https://static.staging.kernelci.org/
+            After testing, you can merge your PR.
+            Note: This is a temporary staging URL, if anyone else will test another PR, it will override contents.
 
       - name: rsync production deployment
         if: github.event_name == 'push' || github.event.inputs.environment == 'production'


### PR DESCRIPTION
Many users get confused about /staging command and doesn't know where to expect website to appear. Fix that, so it will provide info when website got deployed, where it is deployed and caveats.