### PR TITLE
menu: update to reflect current state

### DIFF
--- a/kernelci.org/config.toml
+++ b/kernelci.org/config.toml
@@ -88,13 +88,8 @@ footer_about_disable = false
     url = "/"
   [[menu.main]]
     identifier = "dashboard"
-    name = "Dashboard (WIP)"
+    name = "Dashboard"
     url = "https://dashboard.kernelci.org/"
-
-    [[menu.main]]
-    identifier = "legacy"
-    name = "Legacy KernelCI"
-    url = "https://linux.kernelci.org/job"
 
   [[menu.main]]
     identifier = "blog"


### PR DESCRIPTION
Drop Legacy KernelCI link as that was killed already. And remove WIP mark from the dashboard.