### PR TITLE
kernelci.org: remove obsolete docker-hugo script

### DIFF
--- a/kernelci.org/docker-hugo
+++ b/kernelci.org/docker-hugo
@@ -1,1 +1,0 @@
-docker run --rm -v $PWD:/src klakegg/hugo:0.80.0-ext-debian $@


### PR DESCRIPTION
The docker-hugo script isn't maintained and is now out of sync with docker-compose.yaml.  As such, remove it to avoid causing confusion about its purpose.