### PR TITLE
PyPI ownership

### DIFF
--- a/kernelci.org/content/en/org/maintainers.md
+++ b/kernelci.org/content/en/org/maintainers.md
@@ -115,9 +115,9 @@ using Docker containers.
 
 ## Service maintainers
 
-Services hosted by KernelCI all need someone to look after them and ensure they
-stay online and available.  This is essentially sysadmin work with some code
-maintenance too depending on the cases.
+Services hosted and managed by KernelCI all need someone to look after them and
+ensure they stay online and up to date.  This is essentially sysadmin work with
+some code maintenance too depending on the cases.
 
 ### Kubernetes
 
@@ -162,6 +162,16 @@ Hub](https://hub.docker.com/).  This requires some maintenance in particular to
 keep an eye on resource usage and to adjust permissions.
 
 * Maintainers: `gtucker`, `nuclearcat`
+
+### PyPI
+
+Some KernelCI Python packages are being hosted on the official [Python Package
+Index](https://pypi.org).  They all have a designated maintainer or owner to
+upload new versions and curate the meta-data and documentation shown on the
+package's page itself.
+
+* [kci-dev](https://pypi.org/project/kci-dev/): `arisut`
+* [kernelci](https://pypi.org/project/kernelci/): `nuclearcat`, `arisut`
 
 ## Feature maintainers
 

--- a/kernelci.org/content/en/org/tsc/votes.md
+++ b/kernelci.org/content/en/org/tsc/votes.md
@@ -11,6 +11,8 @@ outcome and a more detailed section listing each individual vote.
 
 | Date                      | Motion                                                          | Status    |
 |---------------------------|-----------------------------------------------------------------|-----------|
+| [2025-03-12](#2025-03-12) | Add Arisu Tachibana as kernelci PyPI co-maintainer              | Approved  |
+| [2025-03-12](#2025-03-12) | Set Denys Fedoryshchenko as kernelci PyPI maintainer            | Approved  |
 | [2025-01-22](#2025-01-22) | Archiving legacy or inactive repositories                       | Approved  |
 | [2024-11-12](#2024-11-12) | Appoint Discord server administrators                           | Approved  |
 | [2024-11-12](#2024-11-12) | Host test catalog prototype repo on the GitHub organization     | Approved  |
@@ -48,6 +50,24 @@ outcome and a more detailed section listing each individual vote.
 | [2021-07-13](#2021-07-13) | Add TSC member: Arisu                                           | Approved  |
 
 ## Votes
+
+### 2025-03-12
+
+**Motion: Set Denys Fedoryshchenko as kernelci PyPI maintainer**
+* Result: approved
+* Effective date: 2025-03-17
+* Voting method: email
+* Voting members: khilman, broonie, gtucker, spbnick, arisut, nuclearcat, pawiecz, shuah
+* Vote count: 8/8/9 in favour
+* Links: [Mail 2024-03-12](https://groups.io/g/kernelci-tsc/message/1223)
+
+**Motion: Add Arisu Tachibana as kernelci PyPI co-maintainer**
+* Result: approved
+* Effective date: 2025-03-17
+* Voting method: email
+* Voting members: khilman, broonie, gtucker, spbnick, arisut, nuclearcat, pawiecz, shuah
+* Vote count: 8/8/9 in favour
+* Links: [Mail 2024-03-12](https://groups.io/g/kernelci-tsc/message/1224)
 
 ### 2025-01-22
 


### PR DESCRIPTION
Add TSC voting records to transfer the `kernelci` PyPI package from `gtucker` to `nuclearcat` and add `arisut` as co-maintainer.

Update the Maintainers page accordingly and add missing entry about the PyPI `kci-dev` package.