### PR TITLE
architecture: drop interrupted sentence

### DIFF
--- a/kernelci.org/content/en/intro/architecture/_index.md
+++ b/kernelci.org/content/en/intro/architecture/_index.md
@@ -12,7 +12,7 @@ description: "Learn the inner details behind the KernelCI systems"
 
 ### [kci-dev](/components/kci-dev)
 
-[kci-dev](/components/kci-dev) is a stand-alone tool for Linux Kernel developers and maintainers to interact with KernelCI directly from their terminal. It is great for There is full documentation available at [kci.dev](https://kci.dev) and a [PyPI package](https://pypi.org/project/kci-dev/). Source code is available on [GitHub](https://github.com/kernelci/kci-dev).
+[kci-dev](/components/kci-dev) is a stand-alone tool for Linux Kernel developers and maintainers to interact with KernelCI directly from their terminal. There is full documentation available at [kci.dev](https://kci.dev) and a [PyPI package](https://pypi.org/project/kci-dev/). Source code is available on [GitHub](https://github.com/kernelci/kci-dev).
 
 ### [Web Dashboard](https://dashboard.kernelci.org/)
 


### PR DESCRIPTION
That sentence was interrupted in the middle. Instead of trying to guess what it was supposed to say, delete it.