### PR TITLE
docs: drop duplicated list of members

### DIFF
--- a/kernelci.org/content/en/org/members.md
+++ b/kernelci.org/content/en/org/members.md
@@ -12,31 +12,4 @@ Learn how your organization can contribute to the project now by [sending us an
 email](mailto:kernelci-members@groups.io?subject=KernelCI%20membership%20information%20request),
 or join the project directly through the [Linux Foundation LFX website](http://joinnow.platform.linuxfoundation.org/?project=kernelci).
 
-Below are the current members of the project.
-
-## Premium Members
-<div class="container">
-  <div class="row row-cols-3">
-    <div class="col p-3"><a href="https://www.cip-project.org/" target="_blank"><img src="/image/cip-stacked-color.svg" alt="Civil Infrastructure Platform" title="Civil Infrastructure Platform" /></a></div>
-    <div class="col p-3"><a href="https://www.collabora.com/" target="_blank"><img src="/image/collabora-stacked-color.svg" alt="Collabora" title="Collabora" /></a></div>
-    <div class="col p-3"><a href="https://www.google.com/" target="_blank"><img src="/image/google-color.svg" alt="Google" title="Google" /></a></div>
-    <div class="col p-3"><a href="https://www.linaro.org/" target="_blank"><img src="/image/linaro-color.svg" alt="Linaro" title="Linaro" /></a></div>
-    <div class="col p-3"><a href="https://www.microsoft.com/" target="_blank"><img src="/image/microsoft-color.svg" alt="Microsoft" title="Microsoft" /></a></div>
-    <div class="col p-3"><a href="https://www.redhat.com/" target="_blank"><img src="/image/redhat-color.svg" alt="Red Hat" title="Red Hat" /></a></div>
-    <div class="col p-3"><a href="https://ti.com/" target="_blank"><img src="/image/texas-instruments.svg" alt="Texas Instruments" title="Texas Instruments" /></a></div>
-  </div>
-</div>
-
-## General Members
-<div class="container">
-  <div class="row row-cols-4">
-    <div class="col p-3"><a href="https://www.baylibre.com/" target="_blank"><img src="/image/baylibre-horizontal-color.svg" alt="Baylibre" title="Baylibre" /></a></div>
-  </div>
-</div>
-
-## Associate Members
-<div class="container">
-  <div class="row row-cols-4">
-    <div class="col p-3"><a href="https://elisa.tech/" target="_blank"><img src="/image/elisa-horizontal-color.svg" alt="ELISA" title="ELISA" /></a></div>
-  </div>
-</div>
+Check our [home page](https://kernelci.org/) to see the current list of members.


### PR DESCRIPTION
We already keep this on our main website. So let's remove this as it was only becoming out-of-date here.

I chose to not remove the logo files. I think it can be a good storage for use in graphs for example.