### PR TITLE
ci: guard updates for missing submodules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,15 +50,15 @@ jobs:
       - name: Submodules init
         run: git submodule update --init --recursive
       - name: Update submodule kernelci-pipeline
-        run: cd kernelci.org/external/kernelci-pipeline;git pull origin main
+        run: if [ -e kernelci.org/external/kernelci-pipeline/.git ]; then git -C kernelci.org/external/kernelci-pipeline pull origin main; fi
       - name: Update submodule kernelci-api
-        run: cd kernelci.org/external/kernelci-api;git pull origin main
+        run: if [ -e kernelci.org/external/kernelci-api/.git ]; then git -C kernelci.org/external/kernelci-api pull origin main; fi
       - name: Update submodule kernelci-core
-        run: cd kernelci.org/external/kernelci-core;git pull origin main
+        run: if [ -e kernelci.org/external/kernelci-core/.git ]; then git -C kernelci.org/external/kernelci-core pull origin main; fi
       - name: Update submodule kcidb
-        run: cd kernelci.org/external/kcidb;git pull origin main
+        run: if [ -e kernelci.org/external/kcidb/.git ]; then git -C kernelci.org/external/kcidb pull origin main; fi
       - name: Update submodule kci-dev
-        run: cd kernelci.org/external/kci-dev;git pull origin main
+        run: if [ -e kernelci.org/external/kci-dev/.git ]; then git -C kernelci.org/external/kci-dev pull origin main; fi
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3


### PR DESCRIPTION
## What changed

Guard each external-submodule update so it only runs when the checked-out
submodule has its own `.git` marker.

## Why

`issue_comment` workflows are loaded from the default branch, then the job
checks out the pull request head. A pull request that removes a submodule can
therefore run the older default-branch workflow against a tree where that
submodule no longer exists.

This caused staging deployment run 29489094118 to fail while trying to enter
`kernelci.org/external/kernelci-core`; `kcidb` would have failed next.

## Impact

Existing submodules continue to update from their `main` branches. Removed or
uninitialized submodules are skipped, allowing submodule-removal pull requests
to use the staging deployment workflow safely.

## Validation

- Parsed `.github/workflows/deploy.yml` with PyYAML.
- Ran `git diff --check`.
- Verified missing or uninitialized submodule paths are skipped successfully.
