### PR TITLE
docs: add a Code of Conduct page

### DIFF
--- a/kernelci.org/content/en/org/code-of-conduct.md
+++ b/kernelci.org/content/en/org/code-of-conduct.md
@@ -1,0 +1,46 @@
+---
+title: "Code of Conduct"
+date: 2026-08-07
+description: "Code of Conduct for the KernelCI project"
+weight: 7
+---
+
+The KernelCI project follows the [LF Projects Code of
+Conduct](https://lfprojects.org/policies/code-of-conduct/).
+
+As per paragraph *5.b Compliance with Policies* of the [project
+charter](/files/KernelCI_Project_Technical_Charter_202607.pdf):
+
+> The TSC may adopt a code of conduct ("CoC") for the Project, which is subject
+> to approval by the Series Manager.  Contributors to the Project will comply
+> with the CoC or, in the event that a Project-specific CoC has not been
+> approved, the LF Projects Code of Conduct listed at
+> https://lfprojects.org/policies/.
+
+The TSC has not adopted a project-specific Code of Conduct, so the LF Projects
+Code of Conduct applies.
+
+## Scope
+
+It applies to everyone taking part in the project, in all project spaces:
+
+* the repositories in the [KernelCI GitHub
+  organization](https://github.com/kernelci)
+* the mailing lists and Discord
+* project meetings, including the community weekly, open hours and working
+  group calls
+* project events and any other space where someone is representing KernelCI
+
+## Reporting
+
+Reporting instructions and contacts are given in the [LF Projects Code of
+Conduct](https://lfprojects.org/policies/code-of-conduct/) itself.  Reports
+made that way are handled by the Linux Foundation rather than by the project.
+
+Concerns may also be raised with the [Technical Steering Committee](/org/tsc/)
+on the [`kernelci-tsc@groups.io`](mailto:<kernelci-tsc@groups.io>) private
+list, or with any individual TSC member if that is more appropriate.
+
+Where a concern involves the TSC itself, or where raising it with the TSC would
+not be appropriate, it may be taken to the Chair of the [Advisory
+Board](/org/board/) instead.


### PR DESCRIPTION
Neither the website nor any repository in the GitHub organization stated which Code of Conduct applies, so contributors had no way to find out.

Section 5.b of the Technical Charter provides that the LF Projects Code of Conduct applies where the TSC has not adopted a project-specific one, which is the case today. Record that, along with the spaces it covers and how to report.