### PR TITLE
docs: document LinkedIn and record current channel access

### DIFF
--- a/kernelci.org/content/en/org/maintainers.md
+++ b/kernelci.org/content/en/org/maintainers.md
@@ -231,7 +231,7 @@ Maintaining them includes moderating incoming messages and new subscriptions,
 keeping settings up-to-date and dealing with changes to the schemes for each
 price plan.
 
-* Maintainers: `broonie`, `khilman`, `padovan`
+* Maintainers: `bhcopeland`, `broonie`, `khilman`, `padovan`
 
 ### Discord
 
@@ -239,7 +239,7 @@ The [KernelCI Discord channel](https://discord.gg/KWbrbWEyqb) may be used as an
 alternative to IRC.  However, more people are using IRC so Discord is only there
 to facilitate communication when IRC is not practical.
 
-* Maintainers: `khilman`, `padovan`
+* Maintainers: `bhcopeland`, `khilman`, `padovan`
 
 ### Twitter
 
@@ -249,6 +249,15 @@ It is also a way for the project to quickly share updates about the project's
 news and, achievements.
 
 * Maintainers: `gtucker`, `padovan`
+
+### LinkedIn
+
+The [KernelCI LinkedIn](https://www.linkedin.com/company/18116276) organization
+page is used to share project news and reach a professional audience.  As a
+project social media account it is owned by the project as per section 6.b of
+the Technical Charter.
+
+* Maintainers: `bhcopeland`
 
 ### kernelci.org update emails (paused)
 


### PR DESCRIPTION
The LinkedIn organization page was missing from the list of project channels even though it is a project social media account under section 6.b of the Technical Charter. Add it alongside the other channels.

Also record existing access to the groups.io lists and the Discord server, which was not reflected in the maintainer lists.