### PR TITLE
docs: remove Gustavo Padovan following his resignation

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-tsc-member.md
+++ b/.github/ISSUE_TEMPLATE/new-tsc-member.md
@@ -2,7 +2,7 @@
 name: New TSC member
 about: Checklist to add a new TSC member
 title: "Add TSC member: FULL NAME"
-assignees: 'padovan'
+assignees: 'bhcopeland'
 ---
 
 Please go through all the checklist below to add @_USERNAME_ (_FULL NAME_) as a member of the [TSC](https://docs.kernelci.org/org/tsc/):

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,8 @@ on:
 jobs:
   deploy_staging:
     if: |
-      (github.event.issue.pull_request && contains('["nuclearcat","JenySadadia","a-wai","broonie","padovan", "patersonc"]', github.actor) && contains(github.event.comment.body, '/staging')) ||
-      (github.event_name == 'workflow_dispatch' && contains('["nuclearcat","JenySadadia","a-wai","broonie","padovan", "patersonc"]', github.actor)) ||
+      (github.event.issue.pull_request && contains('["nuclearcat","JenySadadia","a-wai","broonie","bhcopeland","patersonc"]', github.actor) && contains(github.event.comment.body, '/staging')) ||
+      (github.event_name == 'workflow_dispatch' && contains('["nuclearcat","JenySadadia","a-wai","broonie","bhcopeland","patersonc"]', github.actor)) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-22.04
     environment: stagingdeploy

--- a/kernelci.org/content/en/org/maintainers.md
+++ b/kernelci.org/content/en/org/maintainers.md
@@ -231,7 +231,7 @@ Maintaining them includes moderating incoming messages and new subscriptions,
 keeping settings up-to-date and dealing with changes to the schemes for each
 price plan.
 
-* Maintainers: `bhcopeland`, `broonie`, `khilman`, `padovan`
+* Maintainers: `bhcopeland`, `broonie`, `khilman`
 
 ### Discord
 
@@ -239,7 +239,7 @@ The [KernelCI Discord channel](https://discord.gg/KWbrbWEyqb) may be used as an
 alternative to IRC.  However, more people are using IRC so Discord is only there
 to facilitate communication when IRC is not practical.
 
-* Maintainers: `bhcopeland`, `khilman`, `padovan`
+* Maintainers: `bhcopeland`, `khilman`
 
 ### Twitter
 
@@ -248,7 +248,7 @@ with a wider public audience: events, kernel developers, other test systems...
 It is also a way for the project to quickly share updates about the project's
 news and, achievements.
 
-* Maintainers: `gtucker`, `padovan`
+* Maintainers: `gtucker`
 
 ### LinkedIn
 

--- a/kernelci.org/content/en/org/tsc/_index.md
+++ b/kernelci.org/content/en/org/tsc/_index.md
@@ -22,7 +22,6 @@ respective email address and IRC nicknames:
 * [Ben Copeland](maito:<ben.copeland@linaro.org>)
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - (Infra Committee Lead)
 * [Greg KH](mailto:<gregkh@linuxfoundation.org>)
-* [Gustavo Padovan](mailto:<gus@collabora.com>)
 * [Mark Brown](mailto:<broonie@kernel.org>)
 * [Minas Hambardzumyan](mailto:<minas@ti.com>)
 * [Yogesh Lal](mailto:<yogesh.lal@oss.qualcomm.com>)

--- a/kernelci.org/content/en/org/working-groups.md
+++ b/kernelci.org/content/en/org/working-groups.md
@@ -37,7 +37,6 @@ sub-team as required.
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - Lead
 * [Arisu Tachibana](mailto:<arisu.tachibana@miraclelinux.com>)
 * [Ben Copeland](mailto:<ben.copeland@linaro.org>)
-* [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>)
 * [Jeny Sadadia](mailto:jeny.sadadia@collabora.com)
 * [Mark Brown](mailto:<broonie@kernel.org>)
 * [Paweł Wieczorek](mailto:<pawiecz@collabora.com>)
@@ -80,7 +79,6 @@ Rules can be changed through TSC approval and documented in this git repo.
 * [Ben Copeland](mailto:<ben.copeland@linaro.org>) - `bhcopeland`
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat`
 * [Gustavo Flores](mailto:<gustavobtflores@gmail.com>) - `gustavobtflores`
-* [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan`
 * [João Bertacchi](mailto:<joaobertacchi@gmail.com>) - `joaobertacchi`
 * [Lucas Santos](mailto:<devlucassantoss@gmail.com>) - `LucasSantos27`
 * [Marcelo Robert](mailto:<4mrSantos@gmail.com>) - `MarceloRobert`
@@ -144,7 +142,6 @@ cover the following items:
 
 * [Ben Copeland](mailto:<ben.copeland@linaro.org>) - `bhcopeland` - Lead
 * [Denys Fedoryshchenko](mailto:<denys.f@collabora.com>) - `nuclearcat`
-* [Gustavo Padovan](mailto:<gustavo.padovan@collabora.com>) - `padovan`
 * [Mark Brown](mailto:<broonie@kernel.org>) - `broonie`
 * [Minas Hambardzumyan](mailto:<minas@ti.com>) - `minas_36361`
 


### PR DESCRIPTION
Gustavo has resigned from the project. Remove him from the TSC, from the Infrastructure Committee, Web dashboard and Lab working groups, and from the groups.io and Discord channel maintainer lists.

His Advisory Board entry is left in place, as that seat belongs to Collabora rather than to the TSC. The voting records are left untouched, as they are the historical record of votes as cast.