### PR TITLE
Revert kci-dev maintainer additions

### DIFF
--- a/kernelci.org/content/en/org/maintainers.md
+++ b/kernelci.org/content/en/org/maintainers.md
@@ -101,7 +101,7 @@ common database.
 kci-dev is a command line tool and library for kernel developers and maintainers.
 
 * Main repositories: [`kci-dev`](https://github.com/kernelci/kci-dev)
-* Maintainers: `arisut`, `bhcopeland`, `nuclearcat`
+* Maintainer: `arisut`
 
 ### Tux tools
 


### PR DESCRIPTION
This reverts the kci-dev hunks of commits 328e746 ("docs: add bhcopeland as maintainer of the main components and instances") and df6428f ("docs: add nuclearcat to the API, pipeline and kci-dev maintainers"), restoring arisut as the sole kci-dev maintainer. The other entries touched by those commits are left as they are.